### PR TITLE
feat: add initial internal catalog

### DIFF
--- a/optd-core/src/catalog/mod.rs
+++ b/optd-core/src/catalog/mod.rs
@@ -1,0 +1,1 @@
+pub struct Catalog;

--- a/optd-core/src/catalog/mod.rs
+++ b/optd-core/src/catalog/mod.rs
@@ -1,1 +1,305 @@
-pub struct Catalog;
+use std::sync::Arc;
+
+use sqlx::prelude::FromRow;
+
+use crate::storage::memo::SqliteMemo;
+
+#[trait_variant::make(Send)]
+pub trait Catalog {
+    async fn create_database(&self, db_name: &str) -> anyhow::Result<Arc<DatabaseMetadata>>;
+
+    async fn get_database(&self, db_name: &str) -> anyhow::Result<Arc<DatabaseMetadata>>;
+
+    async fn create_namespace(
+        &self,
+        database_id: DatabaseId,
+        namespace_name: &str,
+    ) -> anyhow::Result<Arc<NamespaceMetadata>>;
+
+    async fn get_namespace(
+        &self,
+        db_name: &str,
+        namespace_name: &str,
+    ) -> anyhow::Result<Arc<NamespaceMetadata>>;
+
+    async fn create_table(
+        &self,
+        namespace_id: NamespaceId,
+        table_name: &str,
+        schema: &Schema,
+    ) -> anyhow::Result<Arc<TableMetadata>>;
+
+    async fn get_table(
+        &self,
+        db_name: &str,
+        namespace_name: &str,
+        table_name: &str,
+    ) -> anyhow::Result<Arc<TableMetadata>>;
+
+    async fn get_schema(&self, table_id: TableId) -> anyhow::Result<Schema>;
+}
+
+pub struct OptdCatalog {
+    storage: Arc<SqliteMemo>,
+}
+
+impl Catalog for OptdCatalog {
+    async fn create_database(&self, db_name: &str) -> anyhow::Result<Arc<DatabaseMetadata>> {
+        let mut txn = self.storage.begin().await?;
+        let db: DatabaseMetadata =
+            sqlx::query_as("INSERT INTO database_metadata (name) VALUES (?) RETURNING id, name")
+                .bind(db_name)
+                .fetch_one(&mut *txn)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to create database metadata for {}: {}", db_name, e)
+                })?;
+        txn.commit().await?;
+        Ok(Arc::new(db))
+    }
+
+    async fn get_database(&self, db_name: &str) -> anyhow::Result<Arc<DatabaseMetadata>> {
+        let mut txn = self.storage.begin().await?;
+        let db: DatabaseMetadata =
+            sqlx::query_as("SELECT id, name FROM database_metadata WHERE name = ?")
+                .bind(db_name)
+                .fetch_one(&mut *txn)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to get database metadata for {}: {}", db_name, e)
+                })?;
+        txn.commit().await?;
+        Ok(Arc::new(db))
+    }
+
+    async fn create_namespace(
+        &self,
+        database_id: DatabaseId,
+        namespace_name: &str,
+    ) -> anyhow::Result<Arc<NamespaceMetadata>> {
+        let mut txn = self.storage.begin().await?;
+        let namespace: NamespaceMetadata = sqlx::query_as(
+            "INSERT INTO namespace_metadata (name, database_id) VALUES (?, ?) RETURNING id, name",
+        )
+        .bind(namespace_name)
+        .bind(database_id)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to create namespace metadata for {}: {}",
+                namespace_name,
+                e
+            )
+        })?;
+        txn.commit().await?;
+        Ok(Arc::new(namespace))
+    }
+
+    async fn get_namespace(
+        &self,
+        db_name: &str,
+        namespace_name: &str,
+    ) -> anyhow::Result<Arc<NamespaceMetadata>> {
+        let mut txn = self.storage.begin().await?;
+        let namespace: NamespaceMetadata = sqlx::query_as(
+            "SELECT namespace_metadata.id, namespace_metadata.name FROM namespace_metadata, database_metadata WHERE database_metadata.name = ? and namspace_metadata.name = ? and namespace_metadata.database_id = database_metadata.id",
+        )
+        .bind(db_name)
+        .bind(namespace_name)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to get namespace metadata for {}.{}: {}",
+                db_name,
+                namespace_name,
+                e
+            )
+        })?;
+        txn.commit().await?;
+        Ok(Arc::new(namespace))
+    }
+
+    async fn create_table(
+        &self,
+        namespace_id: NamespaceId,
+        table_name: &str,
+        schema: &Schema,
+    ) -> anyhow::Result<Arc<TableMetadata>> {
+        let mut txn = self.storage.begin().await?;
+        let table: TableMetadata = sqlx::query_as(
+            "INSERT INTO table_metadata (name, namespace_id) VALUES (?, ?) RETURNING id, name",
+        )
+        .bind(table_name)
+        .bind(namespace_id)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("Failed to create table metadata for {}: {}", table_name, e)
+        })?;
+        for (i, attribute) in schema.attributes.iter().enumerate() {
+            sqlx::query("INSERT INTO attributes (name, kind, table_id, base_attribute_number) VALUES (?, ?, ?, ?)")
+                .bind(&attribute.name)
+                .bind(&attribute.kind)
+                .bind(table.id)
+                .bind(i as i64)
+                .execute(&mut *txn)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to create attribute metadata for {}.{}: {}",
+                        table_name,
+                        attribute.name,
+                        e
+                    )
+                })?;
+        }
+        txn.commit().await?;
+        Ok(Arc::new(table))
+    }
+
+    async fn get_table(
+        &self,
+        db_name: &str,
+        namespace_name: &str,
+        table_name: &str,
+    ) -> anyhow::Result<Arc<TableMetadata>> {
+        let mut txn = self.storage.begin().await?;
+        let table: TableMetadata = sqlx::query_as(
+            "SELECT table_metadata.id, table_metadata.name FROM table_metadata, namespace_metadata, database_metadata WHERE database_metadata.name = ? and namspace_metadata.name = ? and namespace_metadata.database_id = database_metadata.id and table_metadata.namespace_id = namespace_metadata.id and table_metadata.name = ?",
+        )
+        .bind(db_name)
+        .bind(namespace_name)
+        .bind(table_name)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to get table metadata for {}.{}.{}: {}",
+                db_name,
+                namespace_name,
+                table_name,
+                e
+            )
+        })?;
+        txn.commit().await?;
+        Ok(Arc::new(table))
+    }
+
+    async fn get_schema(&self, table_id: TableId) -> anyhow::Result<Schema> {
+        let mut txn = self.storage.begin().await?;
+        let attributes: Vec<Attribute> = sqlx::query_as(
+            "SELECT attributes.id, attributes.name, attributes.kind FROM attributes WHERE attributes.table_id = ?",
+        )
+        .bind(table_id)
+        .fetch_all(&mut *txn)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to get schema metadata for table {:?}: {}",
+                table_id,
+                e
+            )
+        })?;
+
+        Ok(Schema { attributes })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[repr(transparent)]
+#[sqlx(transparent)]
+pub struct DatabaseId(i64);
+
+#[derive(Debug, Clone, PartialEq, Eq, FromRow, sqlx::Type)]
+pub struct DatabaseMetadata {
+    pub id: DatabaseId,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[repr(transparent)]
+#[sqlx(transparent)]
+pub struct NamespaceId(i64);
+
+#[derive(Debug, Clone, PartialEq, Eq, FromRow, sqlx::Type)]
+pub struct NamespaceMetadata {
+    pub id: NamespaceId,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[repr(transparent)]
+#[sqlx(transparent)]
+pub struct TableId(i64);
+
+#[derive(Debug, Clone, PartialEq, Eq, FromRow, sqlx::Type)]
+pub struct TableMetadata {
+    pub id: TableId,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[repr(transparent)]
+#[sqlx(transparent)]
+pub struct AttributeId(i64);
+
+#[derive(Debug, Clone, PartialEq, Eq, FromRow, sqlx::Type)]
+pub struct Attribute {
+    /// The unique identifier for the attribute.
+    pub id: AttributeId,
+    /// The name of the attribute.
+    pub name: String,
+    /// The kind (data type) of the attribute.
+    pub kind: String,
+}
+
+pub struct Schema {
+    /// The attributes in the schema.
+    pub attributes: Vec<Attribute>,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_schema() -> anyhow::Result<()> {
+        let storage = Arc::new(SqliteMemo::new_in_memory().await?);
+        let catalog = OptdCatalog { storage };
+
+        let db = catalog.create_database("test_db").await?;
+        let namespace = catalog.create_namespace(db.id, "test_namespace").await?;
+        let schema = Schema {
+            attributes: vec![
+                Attribute {
+                    id: AttributeId(1),
+                    name: "id".to_string(),
+                    kind: "INTEGER".to_string(),
+                },
+                Attribute {
+                    id: AttributeId(2),
+                    name: "name".to_string(),
+                    kind: "TEXT".to_string(),
+                },
+            ],
+        };
+        let table = catalog
+            .create_table(namespace.id, "test_table", &schema)
+            .await?;
+
+        assert_eq!(table.name, "test_table");
+        assert_eq!(table.id, TableId(1));
+
+        let schema = catalog.get_schema(table.id).await?;
+        assert_eq!(schema.attributes.len(), 2);
+        assert_eq!(schema.attributes[0].name, "id");
+        assert_eq!(schema.attributes[0].kind, "INTEGER");
+        assert_eq!(schema.attributes[1].name, "name");
+        assert_eq!(schema.attributes[1].kind, "TEXT");
+
+        Ok(())
+    }
+}

--- a/optd-core/src/lib.rs
+++ b/optd-core/src/lib.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code)]
 pub mod cascades;
+pub mod catalog;
 pub mod dsl;
 pub mod engine;
 pub mod operators;

--- a/optd-core/src/storage/memo.rs
+++ b/optd-core/src/storage/memo.rs
@@ -74,7 +74,7 @@ impl SqliteMemo {
     }
 
     /// Begin a new transaction.
-    pub(super) async fn begin(&self) -> anyhow::Result<Transaction<'_>> {
+    pub async fn begin(&self) -> anyhow::Result<Transaction<'_>> {
         let txn = self.db.begin().await?;
         Transaction::new(txn).await
     }

--- a/optd-core/src/storage/memo.rs
+++ b/optd-core/src/storage/memo.rs
@@ -74,7 +74,7 @@ impl SqliteMemo {
     }
 
     /// Begin a new transaction.
-    pub async fn begin(&self) -> anyhow::Result<Transaction<'_>> {
+    pub(crate) async fn begin(&self) -> anyhow::Result<Transaction<'_>> {
         let txn = self.db.begin().await?;
         Transaction::new(txn).await
     }

--- a/optd-core/src/storage/migrations/20250122134420_create_events.down.sql
+++ b/optd-core/src/storage/migrations/20250122134420_create_events.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE events;

--- a/optd-core/src/storage/migrations/20250122134420_create_events.up.sql
+++ b/optd-core/src/storage/migrations/20250122134420_create_events.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE events (
+    -- A new epoch is created every time an event happens.
+    epoch_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    -- The type of event that occurred (e.g. )
+     -- TODO(yuchen): need more information than the event type to track what is modified.
+    event_type TEXT NOT NULL,
+    -- The time at which the event occurred.
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);

--- a/optd-core/src/storage/migrations/20250122134422_create_database_metadata.down.sql
+++ b/optd-core/src/storage/migrations/20250122134422_create_database_metadata.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE database_metadata;

--- a/optd-core/src/storage/migrations/20250122134422_create_database_metadata.up.sql
+++ b/optd-core/src/storage/migrations/20250122134422_create_database_metadata.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE database_metadata (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    -- The name of the database.
+    name TEXT NOT NULL,
+    -- The time at which the database was created.
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);

--- a/optd-core/src/storage/migrations/20250122134424_create_namespace_metadata.down.sql
+++ b/optd-core/src/storage/migrations/20250122134424_create_namespace_metadata.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE namespace_metadata;

--- a/optd-core/src/storage/migrations/20250122134424_create_namespace_metadata.up.sql
+++ b/optd-core/src/storage/migrations/20250122134424_create_namespace_metadata.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE namespace_metadata (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    -- The namespace.
+    name TEXT NOT NULL,
+    -- The database that the namespace belongs to.
+    database_id BIGINT NOT NULL,
+    -- The time at which the database was created.
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+
+    FOREIGN KEY (database_id) REFERENCES database_metadata(id) ON DELETE CASCADE
+);

--- a/optd-core/src/storage/migrations/20250122134426_create_table_metadata.down.sql
+++ b/optd-core/src/storage/migrations/20250122134426_create_table_metadata.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE table_metadata;

--- a/optd-core/src/storage/migrations/20250122134426_create_table_metadata.up.sql
+++ b/optd-core/src/storage/migrations/20250122134426_create_table_metadata.up.sql
@@ -1,5 +1,8 @@
 CREATE TABLE table_metadata (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    -- The name of the table,
+    name TEXT NOT NULL,
+    -- The namespace that the table belongs to.
     namespace_id BIGINT NOT NULL,
     -- The time at which the database was created.
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,

--- a/optd-core/src/storage/migrations/20250122134426_create_table_metadata.up.sql
+++ b/optd-core/src/storage/migrations/20250122134426_create_table_metadata.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE table_metadata (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    namespace_id BIGINT NOT NULL,
+    -- The time at which the database was created.
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    
+    FOREIGN KEY (namespace_id) REFERENCES namespace_metadata(id) ON DELETE CASCADE
+);

--- a/optd-core/src/storage/migrations/20250122134428_create_attributes.down.sql
+++ b/optd-core/src/storage/migrations/20250122134428_create_attributes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE attributes;

--- a/optd-core/src/storage/migrations/20250122134428_create_attributes.up.sql
+++ b/optd-core/src/storage/migrations/20250122134428_create_attributes.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE attributes (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    -- The table that the attribute belongs to.
+    table_id BIGINT NOT NULL,
+    -- The name of the attribute.
+    name TEXT NOT NULL,
+    -- The kind of the attribute, integer, varchar, etc.
+    kind TEXT NOT NULL,
+    
+    FOREIGN KEY (table_id) REFERENCES table_metadata(id) ON DELETE CASCADE
+);

--- a/optd-core/src/storage/migrations/20250122134428_create_attributes.up.sql
+++ b/optd-core/src/storage/migrations/20250122134428_create_attributes.up.sql
@@ -6,6 +6,9 @@ CREATE TABLE attributes (
     name TEXT NOT NULL,
     -- The kind of the attribute, integer, varchar, etc.
     kind TEXT NOT NULL,
-    
+    -- The index of the attribute in the table 
+    -- e.g. For t1(v1 INTEGER, v2 TEXT), v1 has base_attribute_number 0 
+    -- and v2 has base_attribute_number 1.
+    base_attribute_number BIGINT NOT NULL,
     FOREIGN KEY (table_id) REFERENCES table_metadata(id) ON DELETE CASCADE
 );

--- a/optd-datafusion-cli/src/main.rs
+++ b/optd-datafusion-cli/src/main.rs
@@ -171,8 +171,7 @@ async fn main_inner() -> Result<()> {
     // enable dynamic file query
     let ctx = optd_datafusion::create_df_context(Some(session_config), Some(runtime_env), None)
         .await
-        .map_err(|e| DataFusionError::External(e.into()))?
-        .enable_url_table();
+        .map_err(|e| DataFusionError::External(e.into()))?;
     ctx.refresh_catalogs().await?;
     // install dynamic catalog provider that can register required object stores
     ctx.register_catalog_list(Arc::new(DynamicObjectStoreCatalog::new(


### PR DESCRIPTION
## Problem

A new event (inserts, deletes, schema changes) might invalidate the memoized winner of a goal (group + required physical properties). With our catalog, we could track these events using epochs and reason about the freshness of the schema and statistics information.

## Summary of changes

- added `events` and other catalog-related tables.
- added a minimum catalog interface.

_misc_

- fix `optd-datafusion-cli` store issue.

## Future works
- add constraints and statistics as we need them in the system.
- embed epoch IDs to schema and statistics.