### PR TITLE
Clean up doc comments and add periods

### DIFF
--- a/optd-core/src/bridge/from_cir.rs
+++ b/optd-core/src/bridge/from_cir.rs
@@ -1,10 +1,6 @@
-use crate::cir::{
-    goal::Goal,
-    group::GroupId,
-    operators::{Child, OperatorData},
-    plans::{PartialLogicalPlan, PartialPhysicalPlan},
-    properties::{LogicalProperties, PhysicalProperties, PropertiesData},
-};
+//! Converts optd's type representations (CIR) into DSL [`Value`]s (HIR).
+
+use crate::cir::*;
 use optd_dsl::analyzer::hir::{
     self, CoreData, Literal, LogicalOp, Materializable, Operator, PhysicalOp, Value,
 };
@@ -13,19 +9,15 @@ use CoreData::*;
 use Literal::*;
 use Materializable::*;
 
-//=============================================================================
-// Main conversion functions
-//=============================================================================
-
-/// Converts a PartialLogicalPlan into a HIR Value representation.
+/// Converts a [`PartialLogicalPlan`] into a [`Value`].
 pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
     match plan {
         PartialLogicalPlan::UnMaterialized(group_id) => {
-            // For unmaterialized logical operators, we create a Value with the group ID
+            // For unmaterialized logical operators, we create a `Value` with the group ID.
             Value(Logical(LogicalOp(UnMaterialized(hir::GroupId(group_id.0)))))
         }
         PartialLogicalPlan::Materialized(node) => {
-            // For materialized logical operators, we create a Value with the operator data
+            // For materialized logical operators, we create a `Value` with the operator data.
             let operator = Operator {
                 tag: node.tag.clone(),
                 data: convert_operator_data_to_values(&node.data),
@@ -37,11 +29,11 @@ pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
     }
 }
 
-/// Converts a PartialPhysicalPlan into a HIR Value representation.
+/// Converts a [`PartialPhysicalPlan`] into a [`Value`].
 pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
     match plan {
         PartialPhysicalPlan::UnMaterialized(goal) => {
-            // For unmaterialized physical operators, we create a Value with the goal
+            // For unmaterialized physical operators, we create a `Value` with the goal
             let hir_goal = cir_goal_to_hir(goal);
             Value(Physical(PhysicalOp(UnMaterialized(hir_goal))))
         }
@@ -58,7 +50,7 @@ pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
     }
 }
 
-/// Converts LogicalProperties to a HIR Value representation.
+/// Converts [`LogicalProperties`] into a [`Value`].
 #[allow(dead_code)]
 pub(crate) fn logical_properties_to_value(properties: &LogicalProperties) -> Value {
     match &properties.0 {
@@ -67,7 +59,7 @@ pub(crate) fn logical_properties_to_value(properties: &LogicalProperties) -> Val
     }
 }
 
-/// Converts PhysicalProperties to a HIR Value representation.
+/// Converts [`PhysicalProperties`] into a [`Value`].
 pub(crate) fn physical_properties_to_value(properties: &PhysicalProperties) -> Value {
     match &properties.0 {
         Some(data) => properties_data_to_value(data),
@@ -75,11 +67,7 @@ pub(crate) fn physical_properties_to_value(properties: &PhysicalProperties) -> V
     }
 }
 
-//=============================================================================
-// CIR to HIR conversion helpers
-//=============================================================================
-
-/// Converts a CIR Goal to a HIR Goal.
+/// Converts a CIR [`Goal`] to a HIR [`Goal`](hir::Goal).
 fn cir_goal_to_hir(goal: &Goal) -> hir::Goal {
     let group_id = cir_group_id_to_hir(&goal.0);
     let properties = physical_properties_to_value(&goal.1);
@@ -90,12 +78,12 @@ fn cir_goal_to_hir(goal: &Goal) -> hir::Goal {
     }
 }
 
-/// Converts a CIR GroupId to a HIR GroupId.
+/// Converts a CIR [`GroupId`] to a HIR [`GroupId`](hir::GroupId).
 fn cir_group_id_to_hir(group_id: &GroupId) -> hir::GroupId {
     hir::GroupId(group_id.0)
 }
 
-/// Generic function to convert a Vec of Children to Vec of Values.
+/// A generic function to convert a slice of children into a vector of [`Value`]s.
 fn convert_children_to_values<T, F>(children: &[Child<Arc<T>>], converter: F) -> Vec<Value>
 where
     F: Fn(&T) -> Value,
@@ -112,12 +100,12 @@ where
         .collect()
 }
 
-/// Converts a slice of OperatorData to a Vec of HIR Values.
+/// Converts a slice of [`OperatorData`] into a vector of [`Value`]s.
 fn convert_operator_data_to_values(data: &[OperatorData]) -> Vec<Value> {
     data.iter().map(operator_data_to_value).collect()
 }
 
-/// Converts an OperatorData to a HIR Value representation.
+/// Converts an [`OperatorData`] into a [`Value`].
 fn operator_data_to_value(data: &OperatorData) -> Value {
     match data {
         OperatorData::Int64(i) => Value(Literal(Int64(*i))),
@@ -132,7 +120,7 @@ fn operator_data_to_value(data: &OperatorData) -> Value {
     }
 }
 
-/// Converts a PropertiesData to a HIR Value representation.
+/// Converts a [`PropertiesData`] into a [`Value`].
 fn properties_data_to_value(data: &PropertiesData) -> Value {
     match data {
         PropertiesData::Int64(i) => Value(Literal(Int64(*i))),

--- a/optd-core/src/bridge/into_cir.rs
+++ b/optd-core/src/bridge/into_cir.rs
@@ -1,10 +1,6 @@
-use crate::cir::{
-    goal::{Cost, Goal},
-    group::GroupId,
-    operators::{Child, Operator, OperatorData},
-    plans::{LogicalPlan, PartialLogicalPlan, PartialPhysicalPlan},
-    properties::{LogicalProperties, PhysicalProperties, PropertiesData},
-};
+//! Converts HIR [`Value`]s into optd's type representations (CIR).
+
+use crate::cir::*;
 use optd_dsl::analyzer::hir::{self, CoreData, Literal, Materializable, Value};
 use std::sync::Arc;
 use Child::*;
@@ -12,13 +8,11 @@ use CoreData::*;
 use Literal::*;
 use Materializable::*;
 
-//=============================================================================
-// Main conversion functions
-//=============================================================================
-
-/// Converts a HIR Value into a PartialLogicalPlan representation.
+/// Converts a [`Value`] into a [`PartialLogicalPlan`].
 ///
-/// Transforms the DSL's HIR into the optimizer's IR for logical operators.
+/// # Panics
+///
+/// Panics if the [`Value`] is not a [`Logical`] variant.
 pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
     match &value.0 {
         Logical(logical_op) => match &logical_op.0 {
@@ -35,9 +29,11 @@ pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
     }
 }
 
-/// Converts a HIR Value into a PartialPhysicalPlan representation.
+/// Converts a [`Value`] into a [`PartialPhysicalPlan`].
 ///
-/// Transforms the DSL's HIR into the CIR for physical operators.
+/// # Panics
+///
+/// Panics if the [`Value`] is not a [`Physical`] variant.
 pub(crate) fn value_to_partial_physical(value: &Value) -> PartialPhysicalPlan {
     match &value.0 {
         Physical(physical_op) => match &physical_op.0 {
@@ -54,7 +50,11 @@ pub(crate) fn value_to_partial_physical(value: &Value) -> PartialPhysicalPlan {
     }
 }
 
-/// Converts a HIR Value into a CIR cost.
+/// Converts a [`Value`] into a CIR [`Cost`].
+///
+/// # Panics
+///
+/// Panics if the [`Value`] is not a [`Literal`] variant with a [`Float64`] value.
 pub(crate) fn value_to_cost(value: &Value) -> Cost {
     match &value.0 {
         Literal(Float64(f)) => Cost(*f),
@@ -62,7 +62,7 @@ pub(crate) fn value_to_cost(value: &Value) -> Cost {
     }
 }
 
-/// Convert HIR properties value to CIR LogicalProperties
+/// Converts an HIR properties [`Value`] into a CIR [`LogicalProperties`].
 pub(crate) fn value_to_logical_properties(properties_value: &Value) -> LogicalProperties {
     match &properties_value.0 {
         Null => LogicalProperties(None),
@@ -70,31 +70,37 @@ pub(crate) fn value_to_logical_properties(properties_value: &Value) -> LogicalPr
     }
 }
 
-/// Converts a HIR GroupId to a CIR GroupId.
+/// Convert an HIR properties [`Value`] into a CIR [`PhysicalProperties`].
+fn value_to_physical_properties(properties_value: &Value) -> PhysicalProperties {
+    match &properties_value.0 {
+        Null => PhysicalProperties(None),
+        _ => PhysicalProperties(Some(value_to_properties_data(properties_value))),
+    }
+}
+
+/// Converts an HIR [`GroupId`](hir::GroupId) to a CIR [`GroupId`].
 ///
-/// This function provides a consistent way to convert group identifiers
-/// from the HIR representation to the optimizer's internal representation.
+/// This function provides a consistent way to convert group identifiers from the HIR into the
+/// optimizer's internal representation (CIR).
 pub(crate) fn hir_group_id_to_cir(hir_group_id: &hir::GroupId) -> GroupId {
     GroupId(hir_group_id.0)
 }
 
-/// Converts a HIR Goal to a CIR Goal.
-///
-/// Transforms the DSL's HIR Goal into the optimizer's IR Goal representation,
-/// handling both the group ID and physical properties components.
+/// Converts an HIR [`Goal`](hir::Goal) to a CIR [`Goal`].
 pub(crate) fn hir_goal_to_cir(hir_goal: &hir::Goal) -> Goal {
     let group_id = hir_group_id_to_cir(&hir_goal.group_id);
     let properties = value_to_physical_properties(&hir_goal.properties);
     Goal(group_id, properties)
 }
 
-//=============================================================================
-// HIR to CIR conversion helpers
-//=============================================================================
-
-/// Converts a HIR Value into a complete LogicalPlan (not a partial plan).
+/// Converts a [`Value`] into a fully materialized [`LogicalPlan`].
 ///
-/// Used when fully materializing a logical expression for use in properties.
+/// We use this function when materializing a logical expression for use in properties.
+///
+/// # Panics
+///
+/// Panics if the [`Value`] is not a [`Logical`] variant or if the [`Logical`] variant is not a
+/// [`Materialized`] variant.
 fn value_to_logical(value: &Value) -> LogicalPlan {
     match &value.0 {
         Logical(logical_op) => match &logical_op.0 {
@@ -111,15 +117,8 @@ fn value_to_logical(value: &Value) -> LogicalPlan {
     }
 }
 
-/// Convert HIR properties value to CIR PhysicalProperties
-fn value_to_physical_properties(properties_value: &Value) -> PhysicalProperties {
-    match &properties_value.0 {
-        Null => PhysicalProperties(None),
-        _ => PhysicalProperties(Some(value_to_properties_data(properties_value))),
-    }
-}
-
-/// Converts a Vec of Values to Vec of Children for any target type.
+/// A generic function to convert a slice of [`Value`]s into a vector of mapped results via the
+/// input `converter` function.
 fn convert_values_to_children<T, F>(values: &[Value], converter: F) -> Vec<Child<Arc<T>>>
 where
     F: Fn(&Value) -> T,
@@ -128,25 +127,32 @@ where
     values
         .iter()
         .map(|value| match &value.0 {
-            Array(elements) => {
-                VarLength(elements.iter().map(|el| Arc::new(converter(el))).collect())
-            }
+            Array(elements) => VarLength(
+                elements
+                    .iter()
+                    .map(|elem| Arc::new(converter(elem)))
+                    .collect(),
+            ),
             _ => Singleton(Arc::new(converter(value))),
         })
         .collect()
 }
 
-/// Converts a slice of HIR Values to a Vec of OperatorData.
+/// Converts a slice of [`Value`]s into a vector of [`OperatorData`].
 fn convert_values_to_operator_data(values: &[Value]) -> Vec<OperatorData> {
     values.iter().map(value_to_operator_data).collect()
 }
 
-/// Converts a slice of HIR Values to a Vec of PropertiesData.
+/// Converts a slice of [`Value`]s into a vector of [`PropertiesData`].
 fn convert_values_to_properties_data(values: &[Value]) -> Vec<PropertiesData> {
     values.iter().map(value_to_properties_data).collect()
 }
 
-/// Converts a HIR Value to an OperatorData representation.
+/// Converts a [`Value`] into an [`OperatorData`] representation.
+///
+/// # Panics
+///
+/// Panics if the [`Value`] cannot be converted to [`OperatorData`], such as a [`Unit`] literal.
 fn value_to_operator_data(value: &Value) -> OperatorData {
     match &value.0 {
         Literal(constant) => match constant {
@@ -164,7 +170,11 @@ fn value_to_operator_data(value: &Value) -> OperatorData {
     }
 }
 
-/// Converts a HIR Value to a PropertiesData representation.
+/// Converts a [`Value`] into a [`PropertiesData`] representation.
+///
+/// # Panics
+///
+/// Panics if the [`Value`] cannot be converted to [`PropertiesData`], such as a [`Unit`] literal.
 fn value_to_properties_data(value: &Value) -> PropertiesData {
     match &value.0 {
         Literal(constant) => match constant {

--- a/optd-core/src/bridge/mod.rs
+++ b/optd-core/src/bridge/mod.rs
@@ -1,13 +1,16 @@
-//! This module provides bridge functionality between the DSL's internal representation (HIR)
-//! and the query optimizer's intermediate representation (Optd-IR).
+//! This module provides bridge functionality between the DSL's internal representation (HIR) and
+//! the query optimizer's intermediate representation (Optd-IR).
 //!
 //! The bridge consists of two main components:
-//! - `into_optd`: Converts HIR Value objects into Optd's PartialPlan representations
-//! - `from_optd`: Converts Optd's PartialPlan representations into HIR Value objects
 //!
-//! These bidirectional conversions enable the DSL to interact with the query optimizer,
-//! allowing rule-based transformations to be applied to query plans while maintaining
-//! the ability to work with both representations.
+//! - [`from_cir`]: Converts optd's type representations (CIR) into DSL [`Value`]s (HIR).
+//! - [`into_cir`]: Converts HIR [`Value`]s into optd's type representations (CIR).
+//!
+//! These bidirectional conversions enable the DSL to interact with the query optimizer, allowing
+//! rule-based transformations to be applied to query plans while maintaining the ability to work
+//! with both representations.
+//!
+//! [`Value`]: optd_dsl::analyzer::hir::Value
 
 pub mod from_cir;
 pub mod into_cir;

--- a/optd-core/src/cir/expressions.rs
+++ b/optd-core/src/cir/expressions.rs
@@ -6,40 +6,32 @@ use super::{
 };
 use std::sync::Arc;
 
-//=============================================================================
-// Expression Types
-//=============================================================================
-
 /// A logical expression in the memo structure.
 ///
-/// Logical expressions use group IDs rather than full plans for their children,
-/// representing a compact form suitable for the memo structure.
+/// Logical expressions have [`GroupId`]s as children rather than full plans, representing a compact
+/// form suitable for the memo structure.
 pub type LogicalExpression = Operator<GroupId>;
 
 /// A physical expression in the memo structure.
 ///
-/// Physical expressions use goal IDs rather than full plans for
-/// their children, representing a compact form suitable for the memo structure.
+/// Physical expressions use [`Goal`]s rather than full plans for their children, representing a
+/// compact form suitable for the memo structure.
 pub type PhysicalExpression = Operator<Goal>;
 
 /// An optimized physical expression with its associated cost.
 #[derive(Clone, Debug)]
 pub struct OptimizedExpression(pub PhysicalExpression, pub Cost);
 
-//=============================================================================
-// Conversion Implementations
-//=============================================================================
-
 impl From<LogicalExpression> for PartialLogicalPlan {
-    /// Converts a logical expression to a partial logical plan.
+    /// Converts a logical expression into a [`PartialLogicalPlan`].
     ///
-    /// This creates a materialized partial plan where each child group ID
-    /// is converted to an unmaterialized partial plan reference.
+    /// This creates a materialized partial plan where each child group ID is converted to an
+    /// unmaterialized partial plan reference.
     fn from(expr: LogicalExpression) -> Self {
         PartialLogicalPlan::Materialized(Operator {
             tag: expr.tag,
             data: expr.data,
-            children: convert_children(expr.children),
+            children: convert_children::<GroupId, Self>(expr.children),
         })
     }
 }
@@ -47,35 +39,21 @@ impl From<LogicalExpression> for PartialLogicalPlan {
 impl From<PhysicalExpression> for PartialPhysicalPlan {
     /// Converts a physical expression to a partial physical plan.
     ///
-    /// This creates a materialized partial plan where each child goal ID
-    /// is converted to an unmaterialized partial plan reference.
+    /// This creates a materialized partial plan where each child goal ID is converted to an
+    /// unmaterialized partial plan reference.
     fn from(expr: PhysicalExpression) -> Self {
         PartialPhysicalPlan::Materialized(Operator {
             tag: expr.tag,
             data: expr.data,
-            children: convert_children(expr.children),
+            children: convert_children::<Goal, Self>(expr.children),
         })
     }
 }
 
-//=============================================================================
-// Helper Functions
-//=============================================================================
-
-/// Generic function to convert a collection of children to partial plan children.
+/// A generic function that converts children with type `S` into a `Arc<T>`.
 ///
-/// This handles both singleton and variable-length children, converting
-/// each source type into its equivalent target wrapped in an Arc.
-///
-/// # Type Parameters
-/// * `S` - Source type (e.g., GroupId)
-/// * `T` - Target type (e.g., PartialLogicalPlan)
-///
-/// # Arguments
-/// * `children` - Collection of child items to convert
-///
-/// # Returns
-/// * Converted collection of partial plan children wrapped in Arc
+/// This handles both singleton and variable-length children, converting each source type into its
+/// equivalent target wrapped in an [`Arc`].
 fn convert_children<S, T>(children: Vec<Child<S>>) -> Vec<Child<Arc<T>>>
 where
     S: Into<T>,

--- a/optd-core/src/cir/goal.rs
+++ b/optd-core/src/cir/goal.rs
@@ -1,11 +1,12 @@
 use super::{group::GroupId, properties::PhysicalProperties};
 
-/// A physical optimization goal, consisting of a group to optimize and
-/// the required physical properties.
+/// A physical optimization goal, consisting of a group to optimize and the required physical
+/// properties.
 ///
-/// Goals are used by the optimizer to find the best physical implementation
-/// of a logical expression that satisfies specific physical property requirements
-/// (like sort order, distribution, etc.).
+/// Goals are used by the optimizer to find the best physical implementation of a logical expression
+/// that satisfies specific physical property requirements (like sort order, distribution, etc.).
+///
+/// Goals can be thought of as the physical counterpart to logical [`GroupId`]s.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Goal(pub GroupId, pub PhysicalProperties);
 

--- a/optd-core/src/cir/group.rs
+++ b/optd-core/src/cir/group.rs
@@ -1,7 +1,12 @@
-/// Unique identifier for a group in the memo structure.
+/// A unique identifier for a group in the memo structure.
 ///
-/// A group in a query optimizer memo represents a set of logically equivalent
-/// expressions. All expressions in a group produce the same result set but may
-/// have different physical implementations and costs.
+/// A group in a represents a set of logically equivalent expressions. All expressions in a group
+/// produce the same result set but may have different physical properties and costs to compute.
+///
+/// This group takes inspiration from Cascades, but is not exactly the same.
+///
+/// The major difference between cascades and optd is that a Cascades group is defined as a class of
+/// equivalent logical **and** physical expressions. In optd, a group is **only** equivalent logical
+/// expressions. optd instead represents physical expressions via [`Goal`]s.
 #[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
 pub struct GroupId(pub i64);

--- a/optd-core/src/cir/mod.rs
+++ b/optd-core/src/cir/mod.rs
@@ -1,7 +1,22 @@
-pub mod expressions;
-pub mod goal;
-pub mod group;
-pub mod operators;
-pub mod plans;
-pub mod properties;
-pub mod rules;
+// This module contains the Core Intermediate Representation (CIR) for optd.
+//!
+//! This module defines core data structures and types used by the query optimizer's internal
+//! processing pipeline. The CIR serves as the canonical representation of plans, expressions,
+//! groups, and properties throughout the optimizer, bridging between the user-facing DSL and the
+//! optimizer's execution engine.
+
+mod expressions;
+mod goal;
+mod group;
+mod operators;
+mod plans;
+mod properties;
+mod rules;
+
+pub use expressions::*;
+pub use goal::*;
+pub use group::*;
+pub use operators::*;
+pub use plans::*;
+pub use properties::*;
+pub use rules::*;

--- a/optd-core/src/cir/operators.rs
+++ b/optd-core/src/cir/operators.rs
@@ -1,51 +1,52 @@
 use ordered_float::OrderedFloat;
 
-/// Represents a child node in an operator tree, which can be either
-/// a single item or a variable-length collection of items.
+/// Represents an operator in the query plan.
 ///
-/// This enumeration provides a flexible way to represent operator children
-/// that may have different arities depending on the operation type.
+/// This generic and unified operator structure can represent logical operations, physical
+/// operations, and scalar expressions, simplifying the type hierarchy.
+///
+/// # Type Parameters
+///
+/// * `T` - Type of children, typically a plan or group reference
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Operator<T> {
+    /// Identifies the specific operation (e.g., "Join", "Filter", "Add").
+    pub tag: String,
+    /// Operation-specific parameters and configuration.
+    pub data: Vec<OperatorData>,
+    /// Child operators that are inputs to this operation.
+    pub children: Vec<Child<T>>,
+}
+
+/// Represents a child node in an operator tree, which can be either a single item (representing a
+/// single child node) or a variable-length collection of items.
+///
+/// This type provides a flexible way to represent operators that may need a variable number of
+/// children.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Child<T> {
-    /// A single child node
+    /// A single child node.
     Singleton(T),
-    /// A variable number of child nodes
+    /// A variable number of child nodes.
     VarLength(Vec<T>),
 }
 
 /// Represents primitive data values that can be stored in operator parameters.
 ///
-/// This enumeration provides a type-safe way to represent the various data types
-/// that can be used as parameters in operators.
+/// This enumeration provides a type-safe way to represent the various data types that can be used
+/// as parameters in operators.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum OperatorData {
-    /// 64-bit signed integer value
+    /// 64-bit signed integer value.
     Int64(i64),
-    /// 64-bit floating point value
+    /// 64-bit floating point value.
     Float64(OrderedFloat<f64>),
-    /// String value
+    /// String value.
     String(String),
-    /// Boolean value
+    /// Boolean value.
     Bool(bool),
-    /// Named structure with fields
+    /// Named structure with fields.
     Struct(String, Vec<OperatorData>),
-    /// Ordered collection of values
+    /// Ordered collection of values.
     Array(Vec<OperatorData>),
-}
-
-/// Represents an operator in the query plan.
-///
-/// This unified operator structure can represent both logical and physical operations,
-/// as well as scalar expressions, simplifying the type hierarchy.
-///
-/// # Type Parameters
-/// * `T` - Type of children, typically a plan or group reference
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Operator<T> {
-    /// Identifies the specific operation (e.g., "Join", "Filter", "Add")
-    pub tag: String,
-    /// Operation-specific parameters and configuration
-    pub data: Vec<OperatorData>,
-    /// Child operators that are inputs to this operation
-    pub children: Vec<Child<T>>,
 }

--- a/optd-core/src/cir/plans.rs
+++ b/optd-core/src/cir/plans.rs
@@ -25,10 +25,18 @@ pub struct PhysicalPlan(pub Operator<Arc<PhysicalPlan>>);
 
 /// Represents partially materialized logical plans.
 ///
-/// Partial logical plans are partially materialized [`LogicalPlan`]s, representing the top of a
-/// logical plan tree, where the unmaterialized leaves of this structure are [`GroupId`]s.
+/// Partial logical plans are partially materialized [`LogicalPlan`]s, representing a connected
+/// sub-tree/DAG. When we say partial, we mean that parts of the plan are not fully materialized,
+/// allowing for more efficient rule matching and binding. However, the parts that _are_
+/// materialized are connected, and they form a valid tree/DAG.
 ///
-/// We use partial plans because most rules only need to match and bind to the top of the
+/// The nodes of a partial plan can either be unmaterialized [`GroupId`]s or materialized
+/// [`Operator`]s (that have other partial plan nodes as children). Because of this, you can cast
+/// both logical expressions (a single operator with groups as children) and logical plans (a
+/// tree/DAG of operators) into a `PartialLogicalPlan`. Note that a partial plan with only an
+/// unmaterialized group at the root is not only possible, but common.
+///
+/// We use partial plans because most rules only need to match and bind to a specific section of a
 /// plan (the root and maybe some of its children), and it would be expensive to materialize the
 /// entire plan when the rule engine only needs to know about the top. In other words, partial plans
 /// allow us to give the rule engine exactly what it needs and nothing else.
@@ -42,8 +50,16 @@ pub enum PartialLogicalPlan {
 
 /// Represents a partially materialized physical plan.
 ///
-/// Partial physical plans are partially materialized [`PhysicalPlan`]s, representing the top of a
-/// physical execution plan tree, where the unmaterialized leaves of this structure are [`Goal`]s.
+/// Partial physical plans are partially materialized [`PhysicalPlan`]s, representing a connected
+/// sub-tree/DAG. When we say partial, we mean that parts of the plan are not fully materialized,
+/// allowing for more efficient rule matching and binding. However, the parts that _are_
+/// materialized are connected, and they form a valid tree/DAG.
+///
+/// The nodes of a partial plan can either be unmaterialized [`Goal`]s or materialized [`Operator`]s
+/// (that have other partial plan nodes as children). Because of this, you can cast both physical
+/// expressions (a single operator with groups as children) and physical plans (a tree/DAG of
+/// operators) into a `PartialPhysicalPlan`. Note that a partial plan with only an unmaterialized
+/// group at the root is not only possible, but common.
 ///
 /// We use partial plans because most rules only need to match and bind to the top of the
 /// plan (the root and maybe some of its children), and it would be expensive to materialize the

--- a/optd-core/src/cir/plans.rs
+++ b/optd-core/src/cir/plans.rs
@@ -5,32 +5,33 @@ use super::{
 };
 use std::sync::Arc;
 
-//=============================================================================
-// Core Plan Types
-//=============================================================================
-
 /// Represents a fully materialized logical query plan.
 ///
-/// A logical plan consists of logical operators arranged in a tree structure,
-/// with each operator having children.
+/// A logical plan consists of logical operators arranged in a tree structure, where each logical
+/// operator has logical plans as children.
+///
+/// Can also represent a DAG structure due to the use of shared [`Arc`]s.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LogicalPlan(pub Operator<Arc<LogicalPlan>>);
 
 /// Represents a fully materialized physical query plan.
 ///
-/// A physical plan consists of physical operators arranged in a tree structure,
-/// with each operator having children.
+/// A physical plan consists of physical operators arranged in a tree structure, where each physical
+/// operator has physical plans as children.
+///
+/// Can also represent a DAG structure due to the use of shared [`Arc`]s.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PhysicalPlan(pub Operator<Arc<PhysicalPlan>>);
 
-//=============================================================================
-// Partial Plan Types
-//=============================================================================
-
-/// Represents a partially materialized logical plan.
+/// Represents partially materialized logical plans.
 ///
-/// Partial logical plans can either be fully materialized with operator trees,
-/// or unmaterialized references to logical groups in the memo structure.
+/// Partial logical plans are partially materialized [`LogicalPlan`]s, representing the top of a
+/// logical plan tree, where the unmaterialized leaves of this structure are [`GroupId`]s.
+///
+/// We use partial plans because most rules only need to match and bind to the top of the
+/// plan (the root and maybe some of its children), and it would be expensive to materialize the
+/// entire plan when the rule engine only needs to know about the top. In other words, partial plans
+/// allow us to give the rule engine exactly what it needs and nothing else.
 #[derive(Clone, Debug, PartialEq)]
 pub enum PartialLogicalPlan {
     /// A fully materialized logical plan with explicit operator and children
@@ -41,19 +42,20 @@ pub enum PartialLogicalPlan {
 
 /// Represents a partially materialized physical plan.
 ///
-/// Partial physical plans can either be fully materialized with operator trees,
-/// or unmaterialized references to physical goals.
+/// Partial physical plans are partially materialized [`PhysicalPlan`]s, representing the top of a
+/// physical execution plan tree, where the unmaterialized leaves of this structure are [`Goal`]s.
+///
+/// We use partial plans because most rules only need to match and bind to the top of the
+/// plan (the root and maybe some of its children), and it would be expensive to materialize the
+/// entire plan when the rule engine only needs to know about the top. In other words, partial plans
+/// allow us to give the rule engine exactly what it needs and nothing else.
 #[derive(Clone, Debug, PartialEq)]
 pub enum PartialPhysicalPlan {
-    /// A fully materialized physical plan with explicit operator and children
+    /// A fully materialized physical plan with explicit operator and children.
     Materialized(Operator<Arc<PartialPhysicalPlan>>),
-    /// A reference to a physical goal
+    /// A reference to a physical goal.
     UnMaterialized(Goal),
 }
-
-//=============================================================================
-// Conversion Implementations
-//=============================================================================
 
 impl From<GroupId> for PartialLogicalPlan {
     /// Converts a logical group ID to an unmaterialized partial logical plan.
@@ -77,7 +79,7 @@ impl From<LogicalPlan> for PartialLogicalPlan {
         PartialLogicalPlan::Materialized(Operator {
             tag: plan.0.tag,
             data: plan.0.data,
-            children: convert_children(plan.0.children),
+            children: convert_children::<LogicalPlan, Self>(plan.0.children),
         })
     }
 }
@@ -90,29 +92,15 @@ impl From<PhysicalPlan> for PartialPhysicalPlan {
         PartialPhysicalPlan::Materialized(Operator {
             tag: plan.0.tag,
             data: plan.0.data,
-            children: convert_children(plan.0.children),
+            children: convert_children::<PhysicalPlan, Self>(plan.0.children),
         })
     }
 }
 
-//=============================================================================
-// Helper Functions
-//=============================================================================
-
-/// Generic function to convert a collection of plan children to partial plan children.
+/// A generic function that converts children with type `Arc<S>` into a `Arc<T>`.
 ///
-/// This handles both singleton and variable-length children, recursively
-/// converting each child plan to its partial equivalent.
-///
-/// # Type Parameters
-/// * `S` - Source plan type
-/// * `T` - Target partial plan type
-///
-/// # Arguments
-/// * `children` - Collection of child plans to convert
-///
-/// # Returns
-/// * Converted collection of partial plan children
+/// This handles both singleton and variable-length children, converting each source type into its
+/// equivalent target wrapped in an [`Arc`].
 fn convert_children<S, T>(children: Vec<Child<Arc<S>>>) -> Vec<Child<Arc<T>>>
 where
     S: Clone,

--- a/optd-core/src/cir/properties.rs
+++ b/optd-core/src/cir/properties.rs
@@ -4,36 +4,36 @@ use super::plans::LogicalPlan;
 
 /// Represents logical properties of a logical group.
 ///
-/// Logical properties describe characteristics of the data produced by
-/// a logical group, such as schema, uniqueness constraints, or statistics.
+/// Logical properties describe logical characteristics of the data produced by a logical group,
+/// such as schema, uniqueness constraints, or statistics.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LogicalProperties(pub Option<PropertiesData>);
 
 /// Represents physical properties of a physical plan node.
 ///
-/// Physical properties describe execution characteristics of a physical plan node,
-/// such as sort order, distribution, or resource requirements.
+/// Physical properties describe physical execution characteristics of a physical plan node, such as
+/// sort order, distribution, or resource requirements.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PhysicalProperties(pub Option<PropertiesData>);
 
-/// Represents various types of property data that can be associated with plan nodes.
+/// Represents various types of property data that can be associated with execution operators.
 ///
-/// This enum provides a flexible way to store different types of metadata and
-/// properties for both logical and physical plan nodes.
+/// This enum provides a flexible way to store different types of metadata and properties for both
+/// logical and physical plan nodes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PropertiesData {
-    /// 64-bit signed integer value
+    /// 64-bit signed integer value.
     Int64(i64),
-    /// 64-bit floating point value
+    /// 64-bit floating point value.
     Float64(OrderedFloat<f64>),
     /// String value
     String(String),
-    /// Boolean value
+    /// Boolean value.
     Bool(bool),
-    /// Named structure with fields
+    /// Named structure with fields.
     Struct(String, Vec<PropertiesData>),
-    /// Ordered collection of values
+    /// Ordered collection of values.
     Array(Vec<PropertiesData>),
-    /// Embedded plan node for nested plan references
+    /// Embedded plan node for nested plan references.
     Logical(LogicalPlan),
 }

--- a/optd-core/src/cir/properties.rs
+++ b/optd-core/src/cir/properties.rs
@@ -16,7 +16,7 @@ pub struct LogicalProperties(pub Option<PropertiesData>);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PhysicalProperties(pub Option<PropertiesData>);
 
-/// Represents various types of property data that can be associated with execution operators.
+/// Represents various types of property data that can be associated with operators.
 ///
 /// This enum provides a flexible way to store different types of metadata and properties for both
 /// logical and physical plan nodes.

--- a/optd-core/src/cir/rules.rs
+++ b/optd-core/src/cir/rules.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, Clone)]
 pub struct TransformationRule(pub String);
+
 #[derive(Debug, Clone)]
 pub struct ImplementationRule(pub String);
 

--- a/optd-core/src/engine/eval/binary.rs
+++ b/optd-core/src/engine/eval/binary.rs
@@ -1,40 +1,32 @@
 //! This module provides implementation for binary operations between values.
 //!
-//! Binary operations are fundamental for expression evaluation, allowing values
-//! to be combined and compared in various ways. The module supports operations on
-//! different value types, including:
-//! - Arithmetic operations on numbers (add, subtract, multiply, divide)
-//! - Comparison operations for various types (equality, less than)
-//! - Logical operations on boolean values (AND, OR)
-//! - Collection operations (concatenation, range creation)
+//! Binary operations are fundamental for expression evaluation, allowing values to be combined and
+//! compared in various ways. The module supports operations on different value types, including:
+//!
+//! - Arithmetic operations on numbers (add, subtract, multiply, divide).
+//! - Comparison operations for various types (equality, less than).
+//! - Logical operations on boolean values (AND, OR).
+//! - Collection operations (concatenation, range creation).
 
 use optd_dsl::analyzer::hir::{BinOp, CoreData, Literal, Value};
 
 /// Evaluates a binary operation between two values.
 ///
-/// This function performs binary operations on values based on their types
-/// and the operation requested. It handles arithmetic, logical, comparison,
-/// and collection operations.
-///
-/// # Parameters
-/// * `left` - The left operand value
-/// * `op` - The binary operation to perform
-/// * `right` - The right operand value
-///
-/// # Returns
-/// The result of applying the operation to the operands
+/// This function performs binary operations on values based on their types and the operation
+/// requested. It handles arithmetic, logical, comparison, and collection operations.
 ///
 /// # Panics
-/// Panics when the operation is not defined for the given operand types
+///
+/// Panics when the operation is not defined for the given operand types.
 pub(super) fn eval_binary_op(left: Value, op: &BinOp, right: Value) -> Value {
     use self::Literal::*;
     use BinOp::*;
     use CoreData::*;
 
-    match (&left.0, op, &right.0) {
-        // Handle operations between two literals
+    match (left.0, op, right.0) {
+        // Handle operations between two literals.
         (Literal(l), op, Literal(r)) => match (l, op, r) {
-            // Integer operations (arithmetic, comparison)
+            // Integer operations (arithmetic, comparison).
             (Int64(l), Add | Sub | Mul | Div | Eq | Lt, Int64(r)) => Value(Literal(match op {
                 Add => Int64(l + r), // Integer addition
                 Sub => Int64(l - r), // Integer subtraction
@@ -45,12 +37,12 @@ pub(super) fn eval_binary_op(left: Value, op: &BinOp, right: Value) -> Value {
                 _ => unreachable!(), // This branch is unreachable due to pattern guard
             })),
 
-            // Integer range operation (creates an array of sequential integers)
+            // Integer range operation (creates an array of sequential integers).
             (Int64(l), Range, Int64(r)) => {
-                Value(Array((*l..=*r).map(|n| Value(Literal(Int64(n)))).collect()))
+                Value(Array((l..=r).map(|n| Value(Literal(Int64(n)))).collect()))
             }
 
-            // Float operations (arithmetic, comparison)
+            // Float operations (arithmetic, comparison).
             (Float64(l), op, Float64(r)) => Value(Literal(match op {
                 Add => Float64(l + r),                  // Float addition
                 Sub => Float64(l - r),                  // Float subtraction
@@ -60,41 +52,41 @@ pub(super) fn eval_binary_op(left: Value, op: &BinOp, right: Value) -> Value {
                 _ => panic!("Invalid float operation"), // Other operations not supported
             })),
 
-            // Boolean operations (logical, comparison)
+            // Boolean operations (logical, comparison).
             (Bool(l), op, Bool(r)) => Value(Literal(match op {
-                And => Bool(*l && *r),                    // Logical AND
-                Or => Bool(*l || *r),                     // Logical OR
-                Eq => Bool(*l == *r),                     // Boolean equality comparison
+                And => Bool(l && r),                      // Logical AND
+                Or => Bool(l || r),                       // Logical OR
+                Eq => Bool(l == r),                       // Boolean equality comparison
                 _ => panic!("Invalid boolean operation"), // Other operations not supported
             })),
 
-            // String operations (comparison, concatenation)
+            // String operations (comparison, concatenation).
             (String(l), op, String(r)) => Value(Literal(match op {
                 Eq => Bool(l == r),                      // String equality comparison
-                Concat => String(l.to_string() + r),     // String concatenation
+                Concat => String(format!("{l}{r}")),     // String concatenation
                 _ => panic!("Invalid string operation"), // Other operations not supported
             })),
 
-            // Any other combination of literal types is not supported
-            _ => panic!("Invalid binary operation: {:?} {:?} {:?}", left, op, right),
+            // Any other combination of literal types is not supported.
+            expr => panic!("Invalid binary operation: {:?}", expr),
         },
 
-        // Array concatenation (joins two arrays)
+        // Array concatenation (joins two arrays).
         (Array(l), Concat, Array(r)) => {
             let mut result = l.clone();
             result.extend(r.iter().cloned());
             Value(Array(result))
         }
 
-        // Map concatenation (joins two maps)
+        // Map concatenation (joins two maps).
         (Map(l), Concat, Map(r)) => {
             let mut result = l.clone();
             result.extend(r.iter().cloned());
             Value(Map(result))
         }
 
-        // Any other combination of value types or operations is not supported
-        _ => panic!("Invalid binary operation: {:?} {:?} {:?}", left, op, right),
+        // Any other combination of value types or operations is not supported.
+        expr => panic!("Invalid binary operation: {:?}", expr),
     }
 }
 

--- a/optd-core/src/engine/eval/core.rs
+++ b/optd-core/src/engine/eval/core.rs
@@ -11,13 +11,14 @@ use CoreData::*;
 
 /// Evaluates a core expression by generating all possible evaluation paths.
 ///
-/// This function dispatches to specialized handlers based on the expression type,
-/// passing all possible values the expression could evaluate to the continuation.
+/// This function dispatches to specialized handlers based on the expression type, passing all
+/// possible values the expression could evaluate to the continuation.
 ///
 /// # Parameters
-/// * `data` - The core expression data to evaluate
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `data` - The core expression data to evaluate.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_core_expr<G>(
     data: CoreData<Arc<Expr>>,
     engine: Engine<G>,
@@ -27,7 +28,7 @@ pub(super) async fn evaluate_core_expr<G>(
 {
     match data {
         Literal(lit) => {
-            // Directly continue with the literal value
+            // Directly continue with the literal value.
             k(Value(Literal(lit))).await;
         }
         Array(items) => {
@@ -43,7 +44,7 @@ pub(super) async fn evaluate_core_expr<G>(
             evaluate_map(items, engine, k).await;
         }
         Function(fun_type) => {
-            // Directly continue with the function value
+            // Directly continue with the function value.
             k(Value(Function(fun_type))).await;
         }
         Fail(msg) => {
@@ -56,7 +57,7 @@ pub(super) async fn evaluate_core_expr<G>(
             evaluate_physical_operator(op, engine, k).await;
         }
         Null => {
-            // Directly continue with null value
+            // Directly continue with null value.
             k(Value(Null)).await;
         }
     }
@@ -65,10 +66,11 @@ pub(super) async fn evaluate_core_expr<G>(
 /// Evaluates a collection expression (Array, Tuple, or Struct).
 ///
 /// # Parameters
-/// * `items` - The collection items to evaluate
-/// * `constructor` - Function to construct the appropriate collection type
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `items` - The collection items to evaluate.
+/// * `constructor` - Function to construct the appropriate collection type.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 async fn evaluate_collection<G, F>(
     items: Vec<Arc<Expr>>,
     constructor: F,
@@ -94,29 +96,30 @@ async fn evaluate_collection<G, F>(
 /// Evaluates a map expression.
 ///
 /// # Parameters
-/// * `items` - The key-value pairs to evaluate
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `items` - The key-value pairs to evaluate.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 async fn evaluate_map<G>(items: Vec<(Arc<Expr>, Arc<Expr>)>, engine: Engine<G>, k: Continuation)
 where
     G: Generator,
 {
-    // Extract keys and values
+    // Extract keys and values.
     let (keys, values): (Vec<Arc<Expr>>, Vec<Arc<Expr>>) = items.into_iter().unzip();
 
-    // First evaluate all key expressions
+    // First evaluate all key expressions.
     evaluate_sequence(
         keys,
         engine.clone(),
         Arc::new(move |keys_values| {
             Box::pin(capture!([values, engine, k], async move {
-                // Then evaluate all value expressions
+                // Then evaluate all value expressions.
                 evaluate_sequence(
                     values,
                     engine,
                     Arc::new(move |values_values| {
                         Box::pin(capture!([keys_values, k], async move {
-                            // Create map from keys and values
+                            // Create a map from keys and values.
                             let map_items = keys_values.into_iter().zip(values_values).collect();
                             k(Value(Map(map_items))).await;
                         }))
@@ -132,6 +135,7 @@ where
 /// Evaluates a fail expression.
 ///
 /// # Parameters
+///
 /// * `msg` - The message expression to evaluate
 /// * `engine` - The evaluation engine
 /// * `k` - The continuation to receive evaluation results
@@ -251,7 +255,7 @@ mod tests {
                     _ => panic!("Expected string literal"),
                 }
                 match &elements[2].0 {
-                    CoreData::Literal(Literal::Bool(value)) => assert_eq!(*value, true),
+                    CoreData::Literal(Literal::Bool(value)) => assert!(*value),
                     _ => panic!("Expected boolean literal"),
                 }
             }

--- a/optd-core/src/engine/eval/expr.rs
+++ b/optd-core/src/engine/eval/expr.rs
@@ -16,15 +16,16 @@ use FunKind::*;
 
 /// Evaluates an if-then-else expression.
 ///
-/// First evaluates the condition, then either the 'then' branch if the condition is true,
-/// or the 'else' branch if the condition is false, passing results to the continuation.
+/// First evaluates the condition, then either the 'then' branch if the condition is true, or the
+/// 'else' branch if the condition is false, passing results to the continuation.
 ///
 /// # Parameters
-/// * `cond` - The condition expression
-/// * `then_expr` - The expression to evaluate if condition is true
-/// * `else_expr` - The expression to evaluate if condition is false
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `cond` - The condition expression.
+/// * `then_expr` - The expression to evaluate if condition is true.
+/// * `else_expr` - The expression to evaluate if condition is false.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_if_then_else<G>(
     cond: Arc<Expr>,
     then_expr: Arc<Expr>,
@@ -57,16 +58,16 @@ pub(super) async fn evaluate_if_then_else<G>(
 
 /// Evaluates a let binding expression.
 ///
-/// Binds the result of evaluating the assignee to the identifier in the context,
-/// then evaluates the 'after' expression in the updated context, passing results
-/// to the continuation.
+/// Binds the result of evaluating the assignee to the identifier in the context, then evaluates the
+/// 'after' expression in the updated context, passing results to the continuation.
 ///
 /// # Parameters
-/// * `ident` - The identifier to bind the value to
-/// * `assignee` - The expression to evaluate and bind
-/// * `after` - The expression to evaluate in the updated context
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `ident` - The identifier to bind the value to.
+/// * `assignee` - The expression to evaluate and bind.
+/// * `after` - The expression to evaluate in the updated context.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_let_binding<G>(
     ident: String,
     assignee: Arc<Expr>,
@@ -76,18 +77,18 @@ pub(super) async fn evaluate_let_binding<G>(
 ) where
     G: Generator,
 {
-    // Evaluate the assignee first
+    // Evaluate the assignee first.
     assignee
         .evaluate(
             engine.clone(),
             Arc::new(move |value| {
                 Box::pin(capture!([ident, after, engine, k], async move {
-                    // Create updated context with the new binding
+                    // Create updated context with the new binding.
                     let mut new_ctx = engine.context.clone();
                     new_ctx.bind(ident, value);
 
-                    // Evaluate the after expression in the updated context
-                    after.evaluate(engine.with_context(new_ctx), k).await;
+                    // Evaluate the after expression in the updated context.
+                    after.evaluate(engine.with_new_context(new_ctx), k).await;
                 }))
             }),
         )
@@ -96,8 +97,8 @@ pub(super) async fn evaluate_let_binding<G>(
 
 /// Evaluates a binary expression.
 ///
-/// Evaluates both operands, then applies the binary operation,
-/// passing the result to the continuation.
+/// Evaluates both operands, then applies the binary operation, passing the result to the
+/// continuation.
 ///
 /// # Parameters
 /// * `left` - The left operand
@@ -114,7 +115,7 @@ pub(super) async fn evaluate_binary_expr<G>(
 ) where
     G: Generator,
 {
-    // Helper function to evaluate the right operand after the left is evaluated
+    // Helper function to evaluate the right operand after the left is evaluated.
     async fn evaluate_right<G>(
         left_val: Value,
         right: Arc<Expr>,
@@ -129,7 +130,7 @@ pub(super) async fn evaluate_binary_expr<G>(
                 engine,
                 Arc::new(move |right_val| {
                     Box::pin(capture!([left_val, op, k], async move {
-                        // Apply the binary operation and pass result to continuation
+                        // Apply the binary operation and pass result to continuation.
                         let result = eval_binary_op(left_val, &op, right_val);
                         k(result).await;
                     }))
@@ -138,7 +139,7 @@ pub(super) async fn evaluate_binary_expr<G>(
             .await;
     }
 
-    // First evaluate the left operand
+    // First evaluate the left operand.
     left.evaluate(
         engine.clone(),
         Arc::new(move |left_val| {
@@ -152,14 +153,14 @@ pub(super) async fn evaluate_binary_expr<G>(
 
 /// Evaluates a unary expression.
 ///
-/// Evaluates the operand, then applies the unary operation,
-/// passing the result to the continuation.
+/// Evaluates the operand, then applies the unary operation, passing the result to the continuation.
 ///
 /// # Parameters
-/// * `op` - The unary operator
-/// * `expr` - The operand expression
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `op` - The unary operator.
+/// * `expr` - The operand expression.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_unary_expr<G>(
     op: UnaryOp,
     expr: Arc<Expr>,
@@ -184,14 +185,15 @@ pub(super) async fn evaluate_unary_expr<G>(
 
 /// Evaluates a function call expression.
 ///
-/// First evaluates the function expression, then the arguments,
-/// and finally applies the function to the arguments, passing results to the continuation.
+/// First evaluates the function expression, then the arguments, and finally applies the function to
+/// the arguments, passing results to the continuation.
 ///
 /// # Parameters
-/// * `fun` - The function expression to evaluate
-/// * `args` - The argument expressions to evaluate
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `fun` - The function expression to evaluate.
+/// * `args` - The argument expressions to evaluate.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_function_call<G>(
     fun: Arc<Expr>,
     args: Vec<Arc<Expr>>,
@@ -200,21 +202,21 @@ pub(super) async fn evaluate_function_call<G>(
 ) where
     G: Generator,
 {
-    // First evaluate the function expression
+    // First evaluate the function expression.
     fun.evaluate(
         engine.clone(),
         Arc::new(move |fun_value| {
             Box::pin(capture!([args, engine, k], async move {
                 match fun_value.0 {
-                    // Handle closure (user-defined function)
+                    // Handle closure (user-defined function).
                     Function(Closure(params, body)) => {
                         evaluate_closure_call(params, body, args, engine, k).await;
                     }
-                    // Handle Rust UDF (built-in function)
+                    // Handle Rust UDF (built-in function).
                     Function(RustUDF(udf)) => {
                         evaluate_rust_udf_call(udf, args, engine, k).await;
                     }
-                    // Value must be a function
+                    // Value must be a function.
                     _ => panic!("Expected function value"),
                 }
             }))
@@ -225,15 +227,16 @@ pub(super) async fn evaluate_function_call<G>(
 
 /// Evaluates a call to a closure (user-defined function).
 ///
-/// Evaluates the arguments, binds them to the parameters in a new context,
-/// then evaluates the function body in that context, passing results to the continuation.
+/// Evaluates the arguments, binds them to the parameters in a new context, then evaluates the
+/// function body in that context, passing results to the continuation.
 ///
 /// # Parameters
-/// * `params` - The parameter names of the closure
-/// * `body` - The body expression of the closure
-/// * `args` - The argument expressions to evaluate
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `params` - The parameter names of the closure.
+/// * `body` - The body expression of the closure.
+/// * `args` - The argument expressions to evaluate.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_closure_call<G>(
     params: Vec<Identifier>,
     body: Arc<Expr>,
@@ -257,7 +260,7 @@ pub(super) async fn evaluate_closure_call<G>(
                 });
 
                 // Evaluate the body in the new context
-                body.evaluate(engine.with_context(new_ctx), k).await;
+                body.evaluate(engine.with_new_context(new_ctx), k).await;
             }))
         }),
     )
@@ -266,10 +269,11 @@ pub(super) async fn evaluate_closure_call<G>(
 
 /// Evaluates a call to a Rust UDF (built-in function).
 ///
-/// Evaluates the arguments, then calls the Rust function with those arguments,
-/// passing the result to the continuation.
+/// Evaluates the arguments, then calls the Rust function with those arguments, passing the result
+/// to the continuation.
 ///
 /// # Parameters
+///
 /// * `udf` - The Rust function to call
 /// * `args` - The argument expressions to evaluate
 /// * `engine` - The evaluation engine
@@ -287,10 +291,10 @@ pub(super) async fn evaluate_rust_udf_call<G>(
         engine,
         Arc::new(move |arg_values| {
             Box::pin(capture!([udf, k], async move {
-                // Call the UDF with the argument values
+                // Call the UDF with the argument values.
                 let result = udf(arg_values);
 
-                // Pass the result to the continuation
+                // Pass the result to the continuation.
                 k(result).await;
             }))
         }),
@@ -303,6 +307,7 @@ pub(super) async fn evaluate_rust_udf_call<G>(
 /// Looks up the variable in the context and passes its value to the continuation.
 ///
 /// # Parameters
+///
 /// * `ident` - The identifier to look up
 /// * `engine` - The evaluation engine
 /// * `k` - The continuation to receive the variable value
@@ -310,14 +315,14 @@ pub(super) async fn evaluate_reference<G>(ident: String, engine: Engine<G>, k: C
 where
     G: Generator,
 {
-    // Look up the variable in the context
+    // Look up the variable in the context.
     let value = engine
         .context
         .lookup(&ident)
         .unwrap_or_else(|| panic!("Variable not found: {}", ident))
         .clone();
 
-    // Pass the value to the continuation
+    // Pass the value to the continuation.
     k(value).await;
 }
 

--- a/optd-core/src/engine/eval/match.rs
+++ b/optd-core/src/engine/eval/match.rs
@@ -11,28 +11,30 @@ use std::sync::Arc;
 use Materializable::*;
 use Pattern::*;
 
-/// Type representing a match result: a value and an optional context
-/// None means the match failed, Some(context) means it succeeded
+/// A type representing a match result, which is a value and an optional context.
+///
+/// None means the match failed, Some(context) means it succeeded.
 type MatchResult = (Value, Option<Context>);
 
-/// Specialized continuation type for match results
+/// Specialized continuation type for match results.
 type MatchContinuation = Arc<dyn Fn(MatchResult) -> UnitFuture + Send + Sync + 'static>;
 
-/// Specialized continuation type for sequence match results
-/// Takes a vector of all match results for the sequence
+/// Specialized continuation type for sequence match results that takes a vector of all match
+/// results for the sequence.
 type MatchSequenceContinuation =
     Arc<dyn Fn(Vec<MatchResult>) -> UnitFuture + Send + Sync + 'static>;
 
 /// Evaluates a pattern match expression.
 ///
-/// First evaluates the expression to match, then tries each match arm in order
-/// until a pattern matches, passing results to the continuation.
+/// First evaluates the expression to match, then tries each match arm in order until a pattern
+/// matches, passing results to the continuation.
 ///
 /// # Parameters
-/// * `expr` - The expression to match against patterns
-/// * `match_arms` - The list of pattern-expression pairs to try
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `expr` - The expression to match against patterns.
+/// * `match_arms` - The list of pattern-expression pairs to try.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_pattern_match<G>(
     expr: Arc<Expr>,
     match_arms: Vec<MatchArm>,
@@ -45,12 +47,12 @@ pub(super) async fn evaluate_pattern_match<G>(
         panic!("Pattern match exhausted: no patterns provided");
     }
 
-    // First evaluate the expression to match
+    // First evaluate the expression to match.
     expr.evaluate(
         engine.clone(),
         Arc::new(move |value| {
             Box::pin(capture!([match_arms, engine, k], async move {
-                // Try to match against each arm in order
+                // Try to match against each arm in order.
                 try_match_arms(value, match_arms, engine, k).await;
             }))
         }),
@@ -64,10 +66,10 @@ pub(super) async fn evaluate_pattern_match<G>(
 /// Evaluates the expression of the first matching arm, or panics if no arm matches.
 ///
 /// # Parameters
-/// * `value` - The value to match against patterns
-/// * `match_arms` - The list of pattern-expression pairs to try
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+/// * `value` - The value to match against patterns.
+/// * `match_arms` - The list of pattern-expression pairs to try.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 fn try_match_arms<G>(
     value: Value,
     match_arms: Vec<MatchArm>,
@@ -97,12 +99,13 @@ where
                     [first_arm, remaining_arms, engine, k],
                     async move {
                         match context_opt {
-                            // If we got a match, evaluate the arm's expression with the context
+                            // If we got a match, evaluate the arm's expression with the context.
                             Some(context) => {
-                                let engine_with_ctx = engine.with_context(context);
+                                let engine_with_ctx = engine.with_new_context(context);
                                 first_arm.expr.evaluate(engine_with_ctx, k).await;
                             }
-                            // If no match, try the next arm with the matching value and remaining arms
+                            // If no match, try the next arm with the matching value and remaining
+                            // arms.
                             None => {
                                 try_match_arms(matched_value, remaining_arms, engine, k).await;
                             }
@@ -118,11 +121,12 @@ where
 /// Attempts to match a value against a pattern.
 ///
 /// # Parameters
-/// * `value` - The value to match against the pattern
-/// * `pattern` - The pattern to match
-/// * `ctx` - The current context to extend with bindings
-/// * `gen` - The generator to resolve references
-/// * `k` - The continuation to receive the match result
+///
+/// * `value` - The value to match against the pattern.
+/// * `pattern` - The pattern to match.
+/// * `ctx` - The current context to extend with bindings.
+/// * `gen` - The generator to resolve references.
+/// * `k` - The continuation to receive the match result.
 fn match_pattern<G>(
     value: Value,
     pattern: Pattern,
@@ -135,7 +139,7 @@ where
 {
     Box::pin(async move {
         match (pattern, &value.0) {
-            // Simple patterns
+            // Simple patterns.
             (Wildcard, _) => {
                 k((value, Some(ctx))).await;
             }
@@ -146,7 +150,7 @@ where
             (EmptyArray, CoreData::Array(arr)) if arr.is_empty() => {
                 k((value, Some(ctx))).await;
             }
-            // Complex patterns
+            // Complex patterns.
             (Bind(ident, inner_pattern), _) => {
                 match_bind_pattern(value.clone(), ident, *inner_pattern, ctx, gen, k).await;
             }
@@ -188,7 +192,7 @@ where
 
                 match_materialized_operator(false, op_pattern, operator.clone(), ctx, gen, k).await;
             }
-            // Unmaterialized operators
+            // Unmaterialized operators.
             (Operator(op_pattern), CoreData::Logical(LogicalOp(UnMaterialized(group_id)))) => {
                 gen.clone()
                     .yield_group(
@@ -215,7 +219,7 @@ where
                     )
                     .await;
             }
-            // No match for other combinations
+            // No match for other combinations.
             _ => {
                 k((value, None)).await;
             }
@@ -223,7 +227,7 @@ where
     })
 }
 
-/// Matches a binding pattern
+/// Matches a binding pattern.
 async fn match_bind_pattern<G>(
     value: Value,
     ident: String,
@@ -234,7 +238,7 @@ async fn match_bind_pattern<G>(
 ) where
     G: Generator,
 {
-    // First check if the inner pattern matches without binding
+    // First check if the inner pattern matches without binding.
     match_pattern(
         value,
         inner_pattern,
@@ -242,13 +246,13 @@ async fn match_bind_pattern<G>(
         generator,
         Arc::new(move |(matched_value, ctx_opt)| {
             Box::pin(capture!([ident, k], async move {
-                // Only bind if the inner pattern matched
+                // Only bind if the inner pattern matched.
                 if let Some(mut ctx) = ctx_opt {
-                    // Create a new context with the binding
+                    // Create a new context with the binding.
                     ctx.bind(ident.clone(), matched_value.clone());
                     k((matched_value, Some(ctx))).await;
                 } else {
-                    // Inner pattern didn't match, propagate failure
+                    // Inner pattern didn't match, propagate failure.
                     k((matched_value, None)).await;
                 }
             }))
@@ -257,7 +261,7 @@ async fn match_bind_pattern<G>(
     .await;
 }
 
-/// Matches an array decomposition pattern
+/// Matches an array decomposition pattern.
 async fn match_array_pattern<G>(
     head_pattern: Pattern,
     tail_pattern: Pattern,
@@ -268,12 +272,12 @@ async fn match_array_pattern<G>(
 ) where
     G: Generator,
 {
-    // Split array into head and tail
+    // Split array into head and tail.
     let head = arr[0].clone();
     let tail_elements = arr[1..].to_vec();
     let tail = Value(CoreData::Array(tail_elements));
 
-    // Create components to match sequentially
+    // Create components to match sequentially.
     let patterns = vec![head_pattern, tail_pattern];
     let values = vec![head, tail];
 
@@ -285,26 +289,26 @@ async fn match_array_pattern<G>(
         generator,
         Arc::new(move |results| {
             Box::pin(capture!([ctx, k], async move {
-                // Check if all parts matched successfully
+                // Check if all parts matched successfully.
                 let all_matched = results.iter().all(|(_, ctx_opt)| ctx_opt.is_some());
 
-                // All matched or not, get the matched values
+                // All matched or not, get the matched values.
                 let head_value = results[0].0.clone();
                 let tail_value = results[1].0.clone();
 
-                // Extract tail elements
+                // Extract tail elements.
                 let tail_elements = match &tail_value.0 {
                     CoreData::Array(elements) => elements.clone(),
                     _ => panic!("Expected Array in tail result"),
                 };
 
-                // Create new array with matched head + tail elements
+                // Create new array with matched head + tail elements.
                 let new_array = Value(CoreData::Array(
                     std::iter::once(head_value).chain(tail_elements).collect(),
                 ));
 
                 if all_matched {
-                    // Combine contexts by folding over the results, starting with the base context
+                    // Combine contexts by folding over the results, starting with the base context.
                     let combined_ctx = results
                         .iter()
                         .filter_map(|(_, ctx_opt)| ctx_opt.clone())
@@ -313,10 +317,10 @@ async fn match_array_pattern<G>(
                             acc_ctx
                         });
 
-                    // Return the new array with the combined context
+                    // Return the new array with the combined context.
                     k((new_array, Some(combined_ctx))).await;
                 } else {
-                    // Return the new array but with None context since match failed
+                    // Return the new array but with None context since match failed.
                     k((new_array, None)).await;
                 }
             }))
@@ -325,7 +329,7 @@ async fn match_array_pattern<G>(
     .await;
 }
 
-/// Matches a struct pattern
+/// Matches a struct pattern.
 async fn match_struct_pattern<G>(
     pat_name: String,
     field_patterns: Vec<Pattern>,
@@ -336,7 +340,7 @@ async fn match_struct_pattern<G>(
 ) where
     G: Generator,
 {
-    // Match fields sequentially
+    // Match fields sequentially.
     match_components(
         field_patterns,
         field_values.to_vec(),
@@ -344,15 +348,15 @@ async fn match_struct_pattern<G>(
         generator,
         Arc::new(move |results| {
             Box::pin(capture!([ctx, pat_name, k], async move {
-                // Check if all fields matched successfully
+                // Check if all fields matched successfully.
                 let all_matched = results.iter().all(|(_, ctx_opt)| ctx_opt.is_some());
 
-                // Reconstruct struct with matched field values
+                // Reconstruct struct with matched field values.
                 let matched_values = results.iter().map(|(v, _)| v.clone()).collect();
                 let new_struct = Value(CoreData::Struct(pat_name, matched_values));
 
                 if all_matched {
-                    // Combine contexts by folding over the results, starting with the base context
+                    // Combine contexts by folding over the results, starting with the base context.
                     let combined_ctx = results
                         .iter()
                         .filter_map(|(_, ctx_opt)| ctx_opt.clone())
@@ -361,10 +365,10 @@ async fn match_struct_pattern<G>(
                             acc_ctx
                         });
 
-                    // Return the new struct with the combined context
+                    // Return the new struct with the combined context.
                     k((new_struct, Some(combined_ctx))).await;
                 } else {
-                    // Return the new struct but with None context since match failed
+                    // Return the new struct but with None context since match failed.
                     k((new_struct, None)).await;
                 }
             }))
@@ -373,7 +377,7 @@ async fn match_struct_pattern<G>(
     .await;
 }
 
-/// Matches a materialized operator
+/// Matches a materialized operator.
 async fn match_materialized_operator<G>(
     is_logical: bool,
     op_pattern: Operator<Pattern>,
@@ -384,7 +388,7 @@ async fn match_materialized_operator<G>(
 ) where
     G: Generator,
 {
-    // Create all patterns and values to match
+    // Create all patterns and values to match.
     let data_patterns = op_pattern.data;
     let children_patterns = op_pattern.children;
     let all_patterns: Vec<Pattern> = data_patterns
@@ -399,7 +403,7 @@ async fn match_materialized_operator<G>(
         .chain(children_values.into_iter())
         .collect();
 
-    // Match all components sequentially
+    // Match all components sequentially.
     match_components(
         all_patterns,
         all_values,
@@ -407,23 +411,23 @@ async fn match_materialized_operator<G>(
         gen,
         Arc::new(move |results| {
             Box::pin(capture!([ctx, operator, k], async move {
-                // Check if all components matched successfully
+                // Check if all components matched successfully.
                 let all_matched = results.iter().all(|(_, ctx_opt)| ctx_opt.is_some());
 
-                // Split results back into data and children
+                // Split results back into data and children.
                 let data_len = operator.data.len();
                 let matched_values: Vec<_> = results.iter().map(|(v, _)| v.clone()).collect();
                 let matched_data = matched_values[..data_len].to_vec();
                 let matched_children = matched_values[data_len..].to_vec();
 
-                // Create new operator with matched components
+                // Create new operator with matched components.
                 let new_op = Operator {
                     tag: operator.tag.clone(),
                     data: matched_data,
                     children: matched_children,
                 };
 
-                // Create appropriate value type based on original_value
+                // Create appropriate value type based on original_value.
                 let new_value = if is_logical {
                     Value(CoreData::Logical(LogicalOp(Materialized(new_op))))
                 } else {
@@ -431,7 +435,7 @@ async fn match_materialized_operator<G>(
                 };
 
                 if all_matched {
-                    // Combine contexts by folding over the results, starting with the base context
+                    // Combine contexts by folding over the results, starting with the base context.
                     let combined_ctx = results
                         .iter()
                         .filter_map(|(_, ctx_opt)| ctx_opt.clone())
@@ -440,10 +444,10 @@ async fn match_materialized_operator<G>(
                             acc_ctx
                         });
 
-                    // Return the new operator with the combined context
+                    // Return the new operator with the combined context.
                     k((new_value, Some(combined_ctx))).await;
                 } else {
-                    // Return the new operator but with None context since match failed
+                    // Return the new operator but with None context since match failed.
                     k((new_value, None)).await;
                 }
             }))
@@ -456,11 +460,12 @@ async fn match_materialized_operator<G>(
 /// against their corresponding patterns sequentially.
 ///
 /// # Parameters
-/// * `patterns` - The patterns to match against
-/// * `values` - The values to match
-/// * `ctx` - The current context to extend with bindings
-/// * `generator` - The generator to resolve references
-/// * `k` - The continuation to receive the vector of match results
+///
+/// * `patterns` - The patterns to match against.
+/// * `values` - The values to match.
+/// * `ctx` - The current context to extend with bindings.
+/// * `generator` - The generator to resolve references.
+/// * `k` - The continuation to receive the vector of match results.
 async fn match_components<G>(
     patterns: Vec<Pattern>,
     values: Vec<Value>,
@@ -470,14 +475,14 @@ async fn match_components<G>(
 ) where
     G: Generator,
 {
-    // Start the sequential matching process with an empty results vector
+    // Start the sequential matching process with an empty results vector.
     match_components_sequentially(patterns, values, 0, ctx, Vec::new(), generator, k).await
 }
 
-/// Internal helper function to match components sequentially
+/// Internal helper function to match components sequentially.
 ///
-/// This function will process all components regardless of match success,
-/// collecting results for each component to allow proper reconstruction of arrays/structs.
+/// This function will process all components regardless of match success, collecting results for
+/// each component to allow proper reconstruction of arrays/structs.
 fn match_components_sequentially<G>(
     patterns: Vec<Pattern>,
     values: Vec<Value>,
@@ -491,13 +496,13 @@ where
     G: Generator,
 {
     Box::pin(async move {
-        // Base case: all components matched
+        // Base case: all components matched.
         if index >= patterns.len() {
             k(results).await;
             return;
         }
 
-        // Match current component
+        // Match current component.
         match_pattern(
             values[index].clone(),
             patterns[index].clone(),
@@ -507,12 +512,12 @@ where
                 Box::pin(capture!(
                     [patterns, values, index, results, ctx, generator, k],
                     async move {
-                        // Add this result to the results vector, keeping the context as is
+                        // Add this result to the results vector, keeping the context as is.
                         // (Some if matched, None if didn't match)
                         let mut updated_results = results;
                         updated_results.push((matched_value, ctx_opt));
 
-                        // Continue to the next component regardless of match outcome
+                        // Continue to the next component regardless of match outcome.
                         match_components_sequentially(
                             patterns,
                             values,

--- a/optd-core/src/engine/eval/mod.rs
+++ b/optd-core/src/engine/eval/mod.rs
@@ -22,6 +22,7 @@ pub trait Evaluate {
     /// Evaluates an expression and passes results to the provided continuation.
     ///
     /// # Parameters
+    ///
     /// * `self` - The expression to evaluate
     /// * `engine` - The evaluation engine (owned)
     /// * `k` - The continuation to receive each evaluation result

--- a/optd-core/src/engine/eval/operator.rs
+++ b/optd-core/src/engine/eval/operator.rs
@@ -15,9 +15,10 @@ type OperatorContinuation = Arc<dyn Fn(Operator<Value>) -> UnitFuture + Send + S
 /// Evaluates a logical operator by generating all possible combinations of its components.
 ///
 /// # Parameters
-/// * `op` - The logical operator to evaluate
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `op` - The logical operator to evaluate.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_logical_operator<G>(
     op: LogicalOp<Arc<Expr>>,
     engine: Engine<G>,
@@ -26,11 +27,12 @@ pub(super) async fn evaluate_logical_operator<G>(
     G: Generator,
 {
     match op.0 {
-        // For unmaterialized operators, directly call the continuation with the unmaterialized value
+        // For unmaterialized operators, directly call the continuation with the unmaterialized
+        // value.
         UnMaterialized(group_id) => {
             k(Value(Logical(LogicalOp(UnMaterialized(group_id))))).await;
         }
-        // For materialized operators, evaluate all parts and construct the result
+        // For materialized operators, evaluate all parts and construct the result.
         Materialized(op) => {
             evaluate_operator(
                 op.data,
@@ -39,7 +41,7 @@ pub(super) async fn evaluate_logical_operator<G>(
                 engine,
                 Arc::new(move |constructed_op| {
                     Box::pin(capture!([k], async move {
-                        // Wrap the constructed operator in the logical operator structure
+                        // Wrap the constructed operator in the logical operator structure.
                         let result = Value(Logical(LogicalOp(Materialized(constructed_op))));
                         k(result).await;
                     }))
@@ -53,9 +55,10 @@ pub(super) async fn evaluate_logical_operator<G>(
 /// Evaluates a physical operator by generating all possible combinations of its components.
 ///
 /// # Parameters
-/// * `op` - The physical operator to evaluate
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive evaluation results
+///
+/// * `op` - The physical operator to evaluate.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
 pub(super) async fn evaluate_physical_operator<G>(
     op: PhysicalOp<Arc<Expr>>,
     engine: Engine<G>,
@@ -64,11 +67,11 @@ pub(super) async fn evaluate_physical_operator<G>(
     G: Generator,
 {
     match op.0 {
-        // For unmaterialized operators, continue with the unmaterialized value
+        // For unmaterialized operators, continue with the unmaterialized value.
         UnMaterialized(physical_goal) => {
             k(Value(Physical(PhysicalOp(UnMaterialized(physical_goal))))).await;
         }
-        // For materialized operators, evaluate all parts and construct the result
+        // For materialized operators, evaluate all parts and construct the result.
         Materialized(op) => {
             evaluate_operator(
                 op.data,
@@ -88,15 +91,16 @@ pub(super) async fn evaluate_physical_operator<G>(
 
 /// Evaluates all components of an operator and constructs the final operator value.
 ///
-/// Evaluates both operator data parameters and children expressions, combining
-/// them to form complete operator instances.
+/// Evaluates both operator data parameters and children expressions, combining them to form
+/// complete operator instances.
 ///
 /// # Parameters
-/// * `op_data_exprs` - The operator parameter expressions to evaluate
-/// * `children_exprs` - The child operator expressions to evaluate
-/// * `tag` - The operator type tag
-/// * `engine` - The evaluation engine
-/// * `k` - The continuation to receive the constructed operator
+///
+/// * `op_data_exprs` - The operator parameter expressions to evaluate.
+/// * `children_exprs` - The child operator expressions to evaluate.
+/// * `tag` - The operator type tag.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive the constructed operator.
 async fn evaluate_operator<G>(
     op_data_exprs: Vec<Arc<Expr>>,
     children_exprs: Vec<Arc<Expr>>,
@@ -106,19 +110,19 @@ async fn evaluate_operator<G>(
 ) where
     G: Generator,
 {
-    // First evaluate all operator data parameters
+    // First evaluate all operator data parameters.
     evaluate_sequence(
         op_data_exprs,
         engine.clone(),
         Arc::new(move |op_data| {
             Box::pin(capture!([children_exprs, tag, engine, k], async move {
-                // Then evaluate all children expressions
+                // Then evaluate all children expressions.
                 evaluate_sequence(
                     children_exprs,
                     engine,
                     Arc::new(move |children| {
                         Box::pin(capture!([tag, op_data, k], async move {
-                            // Construct the complete operator and pass to continuation
+                            // Construct the complete operator and pass to continuation.
                             let operator = Operator {
                                 tag,
                                 data: op_data,

--- a/optd-core/src/engine/eval/unary.rs
+++ b/optd-core/src/engine/eval/unary.rs
@@ -86,9 +86,11 @@ mod tests {
 
     #[test]
     fn test_float_negation() {
+        use std::f64::consts::PI;
+
         // Negating a positive float
-        if let Literal(Float64(result)) = eval_unary_op(&Neg, float(3.14)).0 {
-            assert_eq!(result, -3.14);
+        if let Literal(Float64(result)) = eval_unary_op(&Neg, float(PI)).0 {
+            assert_eq!(result, -PI);
         } else {
             panic!("Expected Float64");
         }
@@ -114,14 +116,14 @@ mod tests {
     fn test_boolean_not() {
         // NOT true
         if let Literal(Bool(result)) = eval_unary_op(&Not, boolean(true)).0 {
-            assert_eq!(result, false);
+            assert!(!result);
         } else {
             panic!("Expected Bool");
         }
 
         // NOT false
         if let Literal(Bool(result)) = eval_unary_op(&Not, boolean(false)).0 {
-            assert_eq!(result, true);
+            assert!(result);
         } else {
             panic!("Expected Bool");
         }

--- a/optd-core/src/engine/generator.rs
+++ b/optd-core/src/engine/generator.rs
@@ -15,8 +15,8 @@ pub type Continuation = Arc<dyn Fn(Value) -> UnitFuture + Send + Sync + 'static>
 pub trait Generator: Clone + Send + Sync + 'static {
     /// Expands a logical group and passes each expression to the continuation.
     ///
-    /// Instead of returning a stream, this function invokes the provided continuation
-    /// for each expression in the group.
+    /// Instead of returning a stream, this function invokes the provided continuation for each
+    /// expression in the group.
     ///
     /// # Parameters
     /// * `group_id` - The ID of the group to expand
@@ -25,8 +25,8 @@ pub trait Generator: Clone + Send + Sync + 'static {
 
     /// Expands a physical goal and passes each implementation to the continuation.
     ///
-    /// Processes physical implementations that satisfy the goal, invoking the continuation
-    /// for each valid implementation.
+    /// Processes physical implementations that satisfy the goal, invoking the continuation for each
+    /// valid implementation.
     ///
     /// # Parameters
     /// * `physical_goal` - The goal describing required properties

--- a/optd-core/src/engine/mod.rs
+++ b/optd-core/src/engine/mod.rs
@@ -9,11 +9,7 @@ use crate::{
         },
     },
     capture,
-    cir::{
-        goal::Cost,
-        plans::{PartialLogicalPlan, PartialPhysicalPlan},
-        properties::{LogicalProperties, PhysicalProperties},
-    },
+    cir::{Cost, LogicalProperties, PartialLogicalPlan, PartialPhysicalPlan, PhysicalProperties},
 };
 use eval::Evaluate;
 use generator::Generator;
@@ -55,9 +51,9 @@ pub(crate) struct Engine<G: Generator> {
     pub(crate) generator: G,
 }
 
-impl<E: Generator> Engine<E> {
+impl<G: Generator> Engine<G> {
     /// Creates a new engine with the given context and expander.
-    pub(crate) fn new(context: Context, generator: E) -> Self {
+    pub(crate) fn new(context: Context, generator: G) -> Self {
         Self { context, generator }
     }
 
@@ -71,17 +67,17 @@ impl<E: Generator> Engine<E> {
     ///
     /// # Returns
     /// A new engine with the provided context and the existing expander
-    pub(crate) fn with_context(self, context: Context) -> Self {
+    pub(crate) fn with_new_context(&self, context: Context) -> Self {
         Self {
             context,
-            generator: self.generator,
+            generator: self.clone().generator,
         }
     }
 
     /// Launches a logical rule application for a given plan.
     ///
-    /// This applies a logical rule to an input plan and passes all possible
-    /// transformations of the plan to the continuation.
+    /// This applies a logical rule to an input plan and passes all possible transformations of the
+    /// plan to the continuation.
     ///
     /// # Parameters
     /// * `rule_name` - The name of the rule to apply

--- a/optd-core/src/engine/test_utils.rs
+++ b/optd-core/src/engine/test_utils.rs
@@ -9,18 +9,18 @@ use optd_dsl::analyzer::hir::{
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-/// A configurable mock generator for testing the evaluation engine
+/// A configurable mock generator for testing the evaluation engine.
 #[derive(Clone)]
 pub struct MockGenerator {
-    /// Maps group IDs to their materialized values
+    /// Maps group IDs to their materialized values.
     group_mappings: Arc<Mutex<HashMap<String, Vec<Value>>>>,
 
-    /// Maps goals to their implementations
+    /// Maps goals to their implementations.
     goal_mappings: Arc<Mutex<HashMap<String, Vec<Value>>>>,
 }
 
 impl MockGenerator {
-    /// Creates a new empty mock generator
+    /// Creates a new empty mock generator.
     pub fn new() -> Self {
         Self {
             group_mappings: Arc::new(Mutex::new(HashMap::new())),
@@ -28,18 +28,18 @@ impl MockGenerator {
         }
     }
 
-    /// Registers a logical operator value to be returned when a specific group is requested
+    /// Registers a logical operator value to be returned when a specific group is requested.
     pub fn register_group(&self, group_id: GroupId, value: Value) {
         let key = format!("{:?}", group_id);
         let mut mappings = self.group_mappings.lock().unwrap();
-        mappings.entry(key).or_insert_with(Vec::new).push(value);
+        mappings.entry(key).or_default().push(value);
     }
 
-    /// Registers a physical operator value to be returned when a specific goal is requested
+    /// Registers a physical operator value to be returned when a specific goal is requested.
     pub fn register_goal(&self, goal: &Goal, value: Value) {
         let key = format!("{:?}:{:?}", goal.group_id, goal.properties);
         let mut mappings = self.goal_mappings.lock().unwrap();
-        mappings.entry(key).or_insert_with(Vec::new).push(value);
+        mappings.entry(key).or_default().push(value);
     }
 }
 
@@ -73,82 +73,82 @@ impl Generator for MockGenerator {
     }
 }
 
-/// Helper to create a literal expression
+/// Helper to create a literal expression.
 pub fn lit_expr(literal: Literal) -> Arc<Expr> {
     Arc::new(Expr::CoreExpr(CoreData::Literal(literal)))
 }
 
-/// Helper to create a literal value
+/// Helper to create a literal value.
 pub fn lit_val(literal: Literal) -> Value {
     Value(CoreData::Literal(literal))
 }
 
-/// Helper to create an integer literal
+/// Helper to create an integer literal.
 pub fn int(i: i64) -> Literal {
     Literal::Int64(i)
 }
 
-/// Helper to create a string literal
+/// Helper to create a string literal.
 pub fn string(s: &str) -> Literal {
     Literal::String(s.to_string())
 }
 
-/// Helper to create a boolean literal
+/// Helper to create a boolean literal.
 pub fn boolean(b: bool) -> Literal {
     Literal::Bool(b)
 }
 
-/// Helper to create a reference expression
+/// Helper to create a reference expression.
 pub fn ref_expr(name: &str) -> Arc<Expr> {
     Arc::new(Expr::Ref(name.to_string()))
 }
 
-/// Helper to create a pattern match arm
+/// Helper to create a pattern match arm.
 pub fn match_arm(pattern: Pattern, expr: Arc<Expr>) -> MatchArm {
     MatchArm { pattern, expr }
 }
 
-/// Helper to create an array value
+/// Helper to create an array value.
 pub fn array_val(items: Vec<Value>) -> Value {
     Value(CoreData::Array(items))
 }
 
-/// Helper to create a struct value
+/// Helper to create a struct value.
 pub fn struct_val(name: &str, fields: Vec<Value>) -> Value {
     Value(CoreData::Struct(name.to_string(), fields))
 }
 
-/// Helper to create a pattern matching expression
+/// Helper to create a pattern matching expression.
 pub fn pattern_match_expr(expr: Arc<Expr>, arms: Vec<MatchArm>) -> Arc<Expr> {
     Arc::new(Expr::PatternMatch(expr, arms))
 }
 
-/// Helper to create a bind pattern
+/// Helper to create a bind pattern.
 pub fn bind_pattern(name: &str, inner: Pattern) -> Pattern {
     Pattern::Bind(name.to_string(), Box::new(inner))
 }
 
-/// Helper to create a wildcard pattern
+/// Helper to create a wildcard pattern.
 pub fn wildcard_pattern() -> Pattern {
     Pattern::Wildcard
 }
 
-/// Helper to create a literal pattern
+/// Helper to create a literal pattern.
 pub fn literal_pattern(lit: Literal) -> Pattern {
     Pattern::Literal(lit)
 }
 
-/// Helper to create a struct pattern
+/// Helper to create a struct pattern.
 pub fn struct_pattern(name: &str, fields: Vec<Pattern>) -> Pattern {
     Pattern::Struct(name.to_string(), fields)
 }
 
-/// Helper to create an array decomposition pattern
+/// Helper to create an array decomposition pattern.
 pub fn array_decomp_pattern(head: Pattern, tail: Pattern) -> Pattern {
     Pattern::ArrayDecomp(Box::new(head), Box::new(tail))
 }
 
-/// Helper to create an operator pattern
+/// Helper to create an operator pattern.
 pub fn operator_pattern(tag: &str, data: Vec<Pattern>, children: Vec<Pattern>) -> Pattern {
     Pattern::Operator(Operator {
         tag: tag.to_string(),
@@ -157,7 +157,7 @@ pub fn operator_pattern(tag: &str, data: Vec<Pattern>, children: Vec<Pattern>) -
     })
 }
 
-/// Helper to create a simple logical operator value
+/// Helper to create a simple logical operator value.
 pub fn create_logical_operator(tag: &str, data: Vec<Value>, children: Vec<Value>) -> Value {
     let op = Operator {
         tag: tag.to_string(),
@@ -170,7 +170,7 @@ pub fn create_logical_operator(tag: &str, data: Vec<Value>, children: Vec<Value>
     ))))
 }
 
-/// Helper to create a simple physical operator value
+/// Helper to create a simple physical operator value.
 pub fn create_physical_operator(tag: &str, data: Vec<Value>, children: Vec<Value>) -> Value {
     let op = Operator {
         tag: tag.to_string(),
@@ -183,7 +183,7 @@ pub fn create_physical_operator(tag: &str, data: Vec<Value>, children: Vec<Value
     )))
 }
 
-/// Runs a test by evaluating the expression and collecting all results
+/// Runs a test by evaluating the expression and collecting all results.
 pub async fn evaluate_and_collect<G>(expr: Arc<Expr>, engine: Engine<G>) -> Vec<Value>
 where
     G: Generator,

--- a/optd-core/src/engine/utils.rs
+++ b/optd-core/src/engine/utils.rs
@@ -6,12 +6,11 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 /// A macro that automatically clones variables before they're captured by a closure.
 ///
-/// This macro takes a list of variables to clone and a closure expression.
-/// It clones all the specified variables *before* creating the closure,
-/// so the closure captures the clones rather than the originals.
+/// This macro takes a list of variables to clone and a closure expression, cloning the variables in
+/// the list so that the clones can be moved into the closure.
 #[macro_export]
 macro_rules! capture {
-    ([$($var:ident),* $(,)?], $($closure:tt)*) => {
+    ([$($var:ident),* $(,)?], $($closure:expr)*) => {
         {
             $(let $var = $var.clone();)*
             $($closure)*
@@ -19,13 +18,14 @@ macro_rules! capture {
     };
 }
 
-/// A future that completes with no return value
-pub(super) type UnitFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+/// A future that completes with no return value.
+pub(crate) type UnitFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
-/// Specialized continuation type for vectors of values
-type ValueSequenceContinuation = Arc<dyn Fn(Vec<Value>) -> UnitFuture + Send + Sync + 'static>;
+/// Specialized continuation type for vectors of values.
+pub(crate) type ValueSequenceContinuation =
+    Arc<dyn Fn(Vec<Value>) -> UnitFuture + Send + Sync + 'static>;
 
-/// Public function to evaluate a sequence of expressions and collect their values.
+/// Evaluates a sequence of expressions and collects their values using continuation passing style.
 ///
 /// # Parameters
 /// * `exprs` - The expressions to evaluate

--- a/optd-core/src/optimizer/egest.rs
+++ b/optd-core/src/optimizer/egest.rs
@@ -1,11 +1,6 @@
 use super::{memo::Memoize, Optimizer};
 use crate::{
-    cir::{
-        expressions::OptimizedExpression,
-        goal::Goal,
-        operators::{Child, Operator},
-        plans::PhysicalPlan,
-    },
+    cir::{Child, Goal, Operator, OptimizedExpression, PhysicalPlan},
     error::Error,
 };
 use async_recursion::async_recursion;

--- a/optd-core/src/optimizer/handlers.rs
+++ b/optd-core/src/optimizer/handlers.rs
@@ -6,12 +6,9 @@ use super::{
 use crate::{
     capture,
     cir::{
-        expressions::{LogicalExpression, OptimizedExpression, PhysicalExpression},
-        goal::Goal,
-        group::GroupId,
-        operators::Child,
-        plans::{LogicalPlan, PartialLogicalPlan, PartialPhysicalPlan, PhysicalPlan},
-        properties::{LogicalProperties, PhysicalProperties},
+        Child, Goal, GroupId, LogicalExpression, LogicalPlan, LogicalProperties,
+        OptimizedExpression, PartialLogicalPlan, PartialPhysicalPlan, PhysicalExpression,
+        PhysicalPlan, PhysicalProperties,
     },
     engine::CostContinuation,
 };

--- a/optd-core/src/optimizer/ingest.rs
+++ b/optd-core/src/optimizer/ingest.rs
@@ -1,15 +1,5 @@
 use super::{memo::Memoize, Optimizer, OptimizerMessage};
-use crate::{
-    cir::{
-        expressions::{LogicalExpression, PhysicalExpression},
-        goal::Goal,
-        group::GroupId,
-        operators::{Child, Operator},
-        plans::{PartialLogicalPlan, PartialPhysicalPlan},
-    },
-    engine::PropertiesContinuation,
-    error::Error,
-};
+use crate::{cir::*, engine::PropertiesContinuation, error::Error};
 use async_recursion::async_recursion;
 use futures::{future::try_join_all, SinkExt};
 use std::{collections::HashSet, sync::Arc};

--- a/optd-core/src/optimizer/memo.rs
+++ b/optd-core/src/optimizer/memo.rs
@@ -1,9 +1,7 @@
 use crate::{
     cir::{
-        expressions::{LogicalExpression, OptimizedExpression, PhysicalExpression},
-        goal::Goal,
-        group::GroupId,
-        properties::LogicalProperties,
+        Goal, GroupId, LogicalExpression, LogicalProperties, OptimizedExpression,
+        PhysicalExpression,
     },
     error::Error,
 };

--- a/optd-core/src/optimizer/mod.rs
+++ b/optd-core/src/optimizer/mod.rs
@@ -1,11 +1,7 @@
 use crate::{
     cir::{
-        expressions::{LogicalExpression, OptimizedExpression},
-        goal::Goal,
-        group::GroupId,
-        plans::{LogicalPlan, PartialLogicalPlan, PartialPhysicalPlan, PhysicalPlan},
-        properties::LogicalProperties,
-        rules::RuleBook,
+        Goal, GroupId, LogicalExpression, LogicalPlan, LogicalProperties, OptimizedExpression,
+        PartialLogicalPlan, PartialPhysicalPlan, PhysicalPlan, RuleBook,
     },
     engine::Engine,
 };

--- a/optd-core/src/optimizer/subscriptions.rs
+++ b/optd-core/src/optimizer/subscriptions.rs
@@ -1,10 +1,8 @@
 use super::{memo::Memoize, Optimizer, OptimizerMessage};
 use crate::{
     cir::{
-        expressions::{LogicalExpression, OptimizedExpression},
-        goal::Goal,
-        group::GroupId,
-        plans::{PartialLogicalPlan, PartialPhysicalPlan},
+        Goal, GroupId, LogicalExpression, OptimizedExpression, PartialLogicalPlan,
+        PartialPhysicalPlan,
     },
     engine::{CostContinuation, LogicalPlanContinuation, PhysicalPlanContinuation},
 };


### PR DESCRIPTION
## Problem

Cleans up a bit of the CPS PR.

## Summary of changes

This commit adds periods to all of the comments in the cir and engine. I also added some more detail here and there.

This commit also unifies all of the types in the cir to make it easier to interact with those types. Imo it makes more sense to have them all in one place rather than to have to figure out the paths to each of them every time you import.

