### PR TITLE
bump to Rust 2024 edition

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,9 +99,8 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        # `Cargo.lock` version 4 requires 1.78.0
-        # datafusion 45.0.0 requires 1.81.0
-        msrv: ["1.81.0"] 
+        # Rust 2024 Edition MSRV
+        msrv: ["1.85.0"] 
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.81.0"
+edition = "2024"
 repository = "https://github.com/cmu-db/optd"
 
 [workspace.dependencies]

--- a/optd-core/Cargo.toml
+++ b/optd-core/Cargo.toml
@@ -2,7 +2,6 @@
 name = "optd-core"
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/optd-core/src/bridge/from_cir.rs
+++ b/optd-core/src/bridge/from_cir.rs
@@ -1,13 +1,13 @@
 //! Converts optd's type representations (CIR) into DSL [`Value`]s (HIR).
 
 use crate::cir::*;
+use CoreData::*;
+use Literal::*;
+use Materializable::*;
 use optd_dsl::analyzer::hir::{
     self, CoreData, Literal, LogicalOp, Materializable, Operator, PhysicalOp, Value,
 };
 use std::sync::Arc;
-use CoreData::*;
-use Literal::*;
-use Materializable::*;
 
 /// Converts a [`PartialLogicalPlan`] into a [`Value`].
 pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {

--- a/optd-core/src/bridge/into_cir.rs
+++ b/optd-core/src/bridge/into_cir.rs
@@ -1,12 +1,12 @@
 //! Converts HIR [`Value`]s into optd's type representations (CIR).
 
 use crate::cir::*;
-use optd_dsl::analyzer::hir::{self, CoreData, Literal, Materializable, Value};
-use std::sync::Arc;
 use Child::*;
 use CoreData::*;
 use Literal::*;
 use Materializable::*;
+use optd_dsl::analyzer::hir::{self, CoreData, Literal, Materializable, Value};
+use std::sync::Arc;
 
 /// Converts a [`Value`] into a [`PartialLogicalPlan`].
 ///

--- a/optd-core/src/engine/eval/binary.rs
+++ b/optd-core/src/engine/eval/binary.rs
@@ -92,11 +92,11 @@ pub(super) fn eval_binary_op(left: Value, op: &BinOp, right: Value) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use optd_dsl::analyzer::hir::{BinOp, CoreData, Literal, Value};
-    use std::collections::HashMap;
     use BinOp::*;
     use CoreData::*;
     use Literal::*;
+    use optd_dsl::analyzer::hir::{BinOp, CoreData, Literal, Value};
+    use std::collections::HashMap;
 
     use super::eval_binary_op;
 

--- a/optd-core/src/engine/eval/core.rs
+++ b/optd-core/src/engine/eval/core.rs
@@ -1,13 +1,13 @@
 use super::{
-    operator::{evaluate_logical_operator, evaluate_physical_operator},
     Engine, Evaluate, Generator,
+    operator::{evaluate_logical_operator, evaluate_physical_operator},
 };
 use crate::capture;
-use crate::engine::utils::evaluate_sequence;
 use crate::engine::Continuation;
+use crate::engine::utils::evaluate_sequence;
+use CoreData::*;
 use optd_dsl::analyzer::hir::{CoreData, Expr, Value};
 use std::sync::Arc;
-use CoreData::*;
 
 /// Evaluates a core expression by generating all possible evaluation paths.
 ///
@@ -160,8 +160,8 @@ where
 #[cfg(test)]
 mod tests {
     use crate::engine::{
-        test_utils::{evaluate_and_collect, int, lit_expr, string, MockGenerator},
         Engine,
+        test_utils::{MockGenerator, evaluate_and_collect, int, lit_expr, string},
     };
     use optd_dsl::analyzer::{
         context::Context,

--- a/optd-core/src/engine/eval/expr.rs
+++ b/optd-core/src/engine/eval/expr.rs
@@ -1,14 +1,14 @@
-use super::{binary::eval_binary_op, unary::eval_unary_op, Evaluate};
+use super::{Evaluate, binary::eval_binary_op, unary::eval_unary_op};
 use crate::{
     capture,
-    engine::{utils::evaluate_sequence, Continuation, Engine, Generator},
+    engine::{Continuation, Engine, Generator, utils::evaluate_sequence},
 };
+use CoreData::*;
+use FunKind::*;
 use optd_dsl::analyzer::hir::{
     BinOp, CoreData, Expr, FunKind, Identifier, Literal, UnaryOp, Value,
 };
 use std::sync::Arc;
-use CoreData::*;
-use FunKind::*;
 
 /// Evaluates an if-then-else expression.
 ///
@@ -325,11 +325,11 @@ where
 #[cfg(test)]
 mod tests {
     use crate::engine::{
-        test_utils::{
-            array_val, boolean, evaluate_and_collect, int, lit_expr, lit_val, ref_expr, string,
-            MockGenerator,
-        },
         Engine,
+        test_utils::{
+            MockGenerator, array_val, boolean, evaluate_and_collect, int, lit_expr, lit_val,
+            ref_expr, string,
+        },
     };
     use optd_dsl::analyzer::{
         context::Context,

--- a/optd-core/src/engine/eval/match.rs
+++ b/optd-core/src/engine/eval/match.rs
@@ -3,6 +3,8 @@ use crate::{
     capture,
     engine::{Continuation, UnitFuture},
 };
+use Materializable::*;
+use Pattern::*;
 use optd_dsl::analyzer::{
     context::Context,
     hir::{
@@ -10,8 +12,6 @@ use optd_dsl::analyzer::{
     },
 };
 use std::sync::Arc;
-use Materializable::*;
-use Pattern::*;
 
 /// A type representing a match result, which is a value and an optional context.
 ///
@@ -133,7 +133,7 @@ fn match_pattern<G>(
     value: Value,
     pattern: Pattern,
     ctx: Context,
-    gen: G,
+    r#gen: G,
     k: MatchContinuation,
 ) -> UnitFuture
 where
@@ -154,7 +154,7 @@ where
             }
             // Complex patterns.
             (Bind(ident, inner_pattern), _) => {
-                match_bind_pattern(value.clone(), ident, *inner_pattern, ctx, gen, k).await;
+                match_bind_pattern(value.clone(), ident, *inner_pattern, ctx, r#gen, k).await;
             }
             (ArrayDecomp(head_pat, tail_pat), CoreData::Array(arr)) => {
                 if arr.is_empty() {
@@ -162,7 +162,7 @@ where
                     return;
                 }
 
-                match_array_pattern(*head_pat, *tail_pat, arr, ctx, gen, k).await;
+                match_array_pattern(*head_pat, *tail_pat, arr, ctx, r#gen, k).await;
             }
             (Struct(pat_name, pat_fields), CoreData::Struct(val_name, val_fields)) => {
                 if pat_name != *val_name || pat_fields.len() != val_fields.len() {
@@ -170,7 +170,7 @@ where
                     return;
                 }
 
-                match_struct_pattern(pat_name, pat_fields, val_fields, ctx, gen, k).await;
+                match_struct_pattern(pat_name, pat_fields, val_fields, ctx, r#gen, k).await;
             }
             (Operator(op_pattern), CoreData::Logical(LogicalOp(Materialized(operator)))) => {
                 if op_pattern.tag != operator.tag
@@ -181,7 +181,8 @@ where
                     return;
                 }
 
-                match_materialized_operator(true, op_pattern, operator.clone(), ctx, gen, k).await;
+                match_materialized_operator(true, op_pattern, operator.clone(), ctx, r#gen, k)
+                    .await;
             }
             (Operator(op_pattern), CoreData::Physical(PhysicalOp(Materialized(operator)))) => {
                 if op_pattern.tag != operator.tag
@@ -192,16 +193,18 @@ where
                     return;
                 }
 
-                match_materialized_operator(false, op_pattern, operator.clone(), ctx, gen, k).await;
+                match_materialized_operator(false, op_pattern, operator.clone(), ctx, r#gen, k)
+                    .await;
             }
             // Unmaterialized operators.
             (Operator(op_pattern), CoreData::Logical(LogicalOp(UnMaterialized(group_id)))) => {
-                gen.clone()
+                r#gen
+                    .clone()
                     .yield_group(
                         *group_id,
                         Arc::new(move |expanded_value| {
-                            Box::pin(capture!([op_pattern, ctx, gen, k], async move {
-                                match_pattern(expanded_value, Operator(op_pattern), ctx, gen, k)
+                            Box::pin(capture!([op_pattern, ctx, r#gen, k], async move {
+                                match_pattern(expanded_value, Operator(op_pattern), ctx, r#gen, k)
                                     .await;
                             }))
                         }),
@@ -209,12 +212,13 @@ where
                     .await;
             }
             (Operator(op_pattern), CoreData::Physical(PhysicalOp(UnMaterialized(goal)))) => {
-                gen.clone()
+                r#gen
+                    .clone()
                     .yield_goal(
                         goal,
                         Arc::new(move |expanded_value| {
-                            Box::pin(capture!([op_pattern, ctx, gen, k], async move {
-                                match_pattern(expanded_value, Operator(op_pattern), ctx, gen, k)
+                            Box::pin(capture!([op_pattern, ctx, r#gen, k], async move {
+                                match_pattern(expanded_value, Operator(op_pattern), ctx, r#gen, k)
                                     .await;
                             }))
                         }),
@@ -385,7 +389,7 @@ async fn match_materialized_operator<G>(
     op_pattern: Operator<Pattern>,
     operator: Operator<Value>,
     ctx: Context,
-    gen: G,
+    r#gen: G,
     k: MatchContinuation,
 ) where
     G: Generator,
@@ -410,7 +414,7 @@ async fn match_materialized_operator<G>(
         all_patterns,
         all_values,
         ctx.clone(),
-        gen,
+        r#gen,
         Arc::new(move |results| {
             Box::pin(capture!([ctx, operator, k], async move {
                 // Check if all components matched successfully.
@@ -541,13 +545,13 @@ where
 #[cfg(test)]
 mod tests {
     use crate::engine::{
+        Engine,
         test_utils::{
-            array_decomp_pattern, array_val, bind_pattern, create_logical_operator,
+            MockGenerator, array_decomp_pattern, array_val, bind_pattern, create_logical_operator,
             create_physical_operator, evaluate_and_collect, int, lit_expr, lit_val,
             literal_pattern, match_arm, operator_pattern, pattern_match_expr, ref_expr, string,
-            struct_pattern, struct_val, wildcard_pattern, MockGenerator,
+            struct_pattern, struct_val, wildcard_pattern,
         },
-        Engine,
     };
     use optd_dsl::analyzer::{
         context::Context,
@@ -1499,9 +1503,11 @@ mod tests {
         for result in &results {
             match &result.0 {
                 CoreData::Literal(Literal::String(s)) => {
-                    assert!(expected_combinations
-                        .map(|(expected, _)| expected)
-                        .contains(&s.as_str()));
+                    assert!(
+                        expected_combinations
+                            .map(|(expected, _)| expected)
+                            .contains(&s.as_str())
+                    );
                 }
                 _ => panic!("Expected string literal"),
             }

--- a/optd-core/src/engine/eval/mod.rs
+++ b/optd-core/src/engine/eval/mod.rs
@@ -1,13 +1,13 @@
 use super::{Continuation, Engine, Generator, UnitFuture};
+use Expr::*;
 use core::evaluate_core_expr;
 use expr::{
     evaluate_binary_expr, evaluate_function_call, evaluate_if_then_else, evaluate_let_binding,
     evaluate_reference, evaluate_unary_expr,
 };
-use optd_dsl::analyzer::hir::{Expr, Value};
 use r#match::evaluate_pattern_match;
+use optd_dsl::analyzer::hir::{Expr, Value};
 use std::sync::Arc;
-use Expr::*;
 
 mod binary;
 mod core;

--- a/optd-core/src/engine/eval/operator.rs
+++ b/optd-core/src/engine/eval/operator.rs
@@ -1,13 +1,13 @@
 use super::{Engine, Generator};
 use crate::capture;
-use crate::engine::utils::evaluate_sequence;
 use crate::engine::Continuation;
+use crate::engine::utils::evaluate_sequence;
+use CoreData::{Logical, Physical};
+use Materializable::*;
 use optd_dsl::analyzer::hir::{
     CoreData, Expr, LogicalOp, Materializable, Operator, PhysicalOp, Value,
 };
 use std::sync::Arc;
-use CoreData::{Logical, Physical};
-use Materializable::*;
 
 /// Specialized continuation type for operator values
 type OperatorContinuation = Continuation<Operator<Value>>;
@@ -142,11 +142,11 @@ async fn evaluate_operator<G>(
 #[cfg(test)]
 mod tests {
     use crate::engine::{
-        test_utils::{
-            create_logical_operator, evaluate_and_collect, int, lit_expr, lit_val, string,
-            MockGenerator,
-        },
         Engine,
+        test_utils::{
+            MockGenerator, create_logical_operator, evaluate_and_collect, int, lit_expr, lit_val,
+            string,
+        },
     };
     use optd_dsl::analyzer::{
         context::Context,

--- a/optd-core/src/engine/eval/unary.rs
+++ b/optd-core/src/engine/eval/unary.rs
@@ -5,10 +5,10 @@
 //! - Numeric negation for integers and floating-point numbers
 //! - Logical NOT for boolean values
 
-use optd_dsl::analyzer::hir::{CoreData, Literal, UnaryOp, Value};
 use CoreData::*;
 use Literal::*;
 use UnaryOp::*;
+use optd_dsl::analyzer::hir::{CoreData, Literal, UnaryOp, Value};
 
 /// Evaluates a unary operation on a value.
 ///

--- a/optd-core/src/engine/mod.rs
+++ b/optd-core/src/engine/mod.rs
@@ -12,13 +12,13 @@ use crate::{
     cir::{Cost, LogicalProperties, PartialLogicalPlan, PartialPhysicalPlan, PhysicalProperties},
 };
 
+use Expr::*;
 use optd_dsl::analyzer::{
     context::Context,
     hir::{CoreData, Expr, Literal, Value},
 };
 use std::sync::Arc;
 use utils::UnitFuture;
-use Expr::*;
 
 mod eval;
 use eval::Evaluate;

--- a/optd-core/src/engine/test_utils.rs
+++ b/optd-core/src/engine/test_utils.rs
@@ -1,4 +1,4 @@
-use crate::engine::{generator::Generator, Continuation, Engine, Evaluate};
+use crate::engine::{Continuation, Engine, Evaluate, generator::Generator};
 use optd_dsl::analyzer::hir::{
     CoreData, Expr, Goal, GroupId, Literal, LogicalOp, MatchArm, Materializable, Operator, Pattern,
     PhysicalOp, Value,

--- a/optd-core/src/engine/utils.rs
+++ b/optd-core/src/engine/utils.rs
@@ -1,6 +1,6 @@
 use super::eval::Evaluate;
 use crate::capture;
-use crate::engine::{generator::Generator, Engine};
+use crate::engine::{Engine, generator::Generator};
 use optd_dsl::analyzer::hir::{Expr, Value};
 use std::{future::Future, pin::Pin, sync::Arc};
 

--- a/optd-core/src/optimizer/egest.rs
+++ b/optd-core/src/optimizer/egest.rs
@@ -1,12 +1,12 @@
-use super::{memo::Memoize, Optimizer};
+use super::{Optimizer, memo::Memoize};
 use crate::{
     cir::{Child, Goal, Operator, OptimizedExpression, PhysicalPlan},
     error::Error,
 };
+use Child::*;
 use async_recursion::async_recursion;
 use futures::future::try_join_all;
 use std::sync::Arc;
-use Child::*;
 
 impl<M: Memoize> Optimizer<M> {
     /// Egest a physical plan from the memo table based on the best available physical expressions.

--- a/optd-core/src/optimizer/generator.rs
+++ b/optd-core/src/optimizer/generator.rs
@@ -7,8 +7,8 @@ use crate::{
     engine::{Continuation, Generator},
 };
 use futures::{
-    channel::mpsc::{self, Sender},
     SinkExt, StreamExt,
+    channel::mpsc::{self, Sender},
 };
 use optd_dsl::analyzer::hir::{Goal, GroupId, Value};
 

--- a/optd-core/src/optimizer/handlers.rs
+++ b/optd-core/src/optimizer/handlers.rs
@@ -1,7 +1,7 @@
 use super::{
+    OptimizeRequest, Optimizer, OptimizerMessage, PendingMessage,
     ingest::{LogicalIngest, PhysicalIngest},
     memo::{Memoize, MergeResult},
-    OptimizeRequest, Optimizer, OptimizerMessage, PendingMessage,
 };
 use crate::{
     capture,
@@ -12,15 +12,15 @@ use crate::{
     },
     engine::Continuation,
 };
+use OptimizerMessage::*;
 use futures::{
+    SinkExt, StreamExt,
     channel::{
         mpsc::{self, Sender},
         oneshot,
     },
-    SinkExt, StreamExt,
 };
 use std::sync::Arc;
-use OptimizerMessage::*;
 
 impl<M: Memoize> Optimizer<M> {
     /// This method initiates the optimization process for a logical plan and streams

--- a/optd-core/src/optimizer/ingest.rs
+++ b/optd-core/src/optimizer/ingest.rs
@@ -1,10 +1,10 @@
-use super::{memo::Memoize, Optimizer, OptimizerMessage};
+use super::{Optimizer, OptimizerMessage, memo::Memoize};
 use crate::{cir::*, engine::Continuation, error::Error};
-use async_recursion::async_recursion;
-use futures::{future::try_join_all, SinkExt};
-use std::{collections::HashSet, sync::Arc};
 use Child::*;
 use OptimizerMessage::CreateGroup;
+use async_recursion::async_recursion;
+use futures::{SinkExt, future::try_join_all};
+use std::{collections::HashSet, sync::Arc};
 
 /// Result type for logical plan ingestion exposed to clients
 pub(super) enum LogicalIngest {

--- a/optd-core/src/optimizer/mod.rs
+++ b/optd-core/src/optimizer/mod.rs
@@ -5,18 +5,18 @@ use crate::{
     },
     engine::Engine,
 };
-use futures::channel::oneshot;
+use OptimizerMessage::*;
 use futures::StreamExt;
+use futures::channel::oneshot;
 use futures::{
-    channel::mpsc::{self, Receiver, Sender},
     SinkExt,
+    channel::mpsc::{self, Receiver, Sender},
 };
 use generator::OptimizerGenerator;
 use memo::Memoize;
 use merge_repr::Representative;
 use optd_dsl::analyzer::hir::HIR;
 use std::collections::{HashMap, HashSet};
-use OptimizerMessage::*;
 
 mod egest;
 mod generator;

--- a/optd-core/src/optimizer/subscriptions.rs
+++ b/optd-core/src/optimizer/subscriptions.rs
@@ -1,4 +1,4 @@
-use super::{memo::Memoize, Optimizer, OptimizerMessage};
+use super::{Optimizer, OptimizerMessage, memo::Memoize};
 use crate::{
     cir::{
         Cost, Goal, GroupId, LogicalExpression, OptimizedExpression, PartialLogicalPlan,
@@ -6,13 +6,13 @@ use crate::{
     },
     engine::Continuation,
 };
+use OptimizerMessage::*;
 use async_recursion::async_recursion;
 use futures::{
-    channel::mpsc::{self, Sender},
     SinkExt, StreamExt,
+    channel::mpsc::{self, Sender},
 };
 use std::sync::Arc;
-use OptimizerMessage::*;
 
 impl<M: Memoize> Optimizer<M> {
     /// Subscribe to logical expressions in a specific group.

--- a/optd-dsl/Cargo.toml
+++ b/optd-dsl/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "optd-dsl"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
 
 [dependencies]
 chumsky = "0.9.3"

--- a/optd-dsl/src/cli/main.rs
+++ b/optd-dsl/src/cli/main.rs
@@ -24,7 +24,7 @@
 //! ```
 
 use clap::{Parser, Subcommand};
-use optd_dsl::compiler::compile::{parse, CompileOptions};
+use optd_dsl::compiler::compile::{CompileOptions, parse};
 use optd_dsl::utils::error::Diagnose;
 use std::fs;
 use std::path::PathBuf;

--- a/optd-dsl/src/lexer/lex.rs
+++ b/optd-dsl/src/lexer/lex.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use chumsky::{
+    Parser, Stream,
     error::Simple,
     prelude::{choice, end, just, none_of, skip_then_retry_until},
-    text::{digits, ident, int, TextParser},
-    Parser, Stream,
+    text::{TextParser, digits, ident, int},
 };
 use ordered_float::OrderedFloat;
 

--- a/optd-dsl/src/parser/adt.rs
+++ b/optd-dsl/src/parser/adt.rs
@@ -1,7 +1,8 @@
 use chumsky::{
+    Parser,
     error::Simple,
     prelude::{choice, just, recursive},
-    select, Parser,
+    select,
 };
 
 use crate::{
@@ -49,7 +50,7 @@ pub fn adt_parser() -> impl Parser<Token, Spanned<Adt>, Error = Simple<Token, Sp
 mod tests {
     use super::*;
     use crate::{lexer::lex::lex, parser::ast::Type};
-    use chumsky::{prelude::end, Stream};
+    use chumsky::{Stream, prelude::end};
 
     fn parse_adt(input: &str) -> (Option<Spanned<Adt>>, Vec<Simple<Token, Span>>) {
         let (tokens, _) = lex(input, "test.txt");

--- a/optd-dsl/src/parser/expr.rs
+++ b/optd-dsl/src/parser/expr.rs
@@ -1,7 +1,8 @@
 use chumsky::{
+    Parser,
     error::Simple,
     prelude::{choice, just, recursive},
-    select, Parser,
+    select,
 };
 
 use crate::{
@@ -351,7 +352,7 @@ mod tests {
         lexer::lex::lex,
         parser::ast::{Expr, Literal, Pattern},
     };
-    use chumsky::{prelude::end, Stream};
+    use chumsky::{Stream, prelude::end};
     use ordered_float::OrderedFloat;
 
     fn parse_expr(input: &str) -> (Option<Spanned<Expr>>, Vec<Simple<Token, Span>>) {
@@ -1663,7 +1664,7 @@ mod tests {
     fn test_list_decomposition_match() {
         // Complex match expression with list decomposition patterns
         let (result, errors) = parse_expr(
-        "match numbers \
+            "match numbers \
          | [] -> \"empty list\" \
          | [x .. []] -> \"list with one element: \" ++ x.to_string() \
          | [x .. [y .. []]] -> \"list with two elements: \" ++ x.to_string() ++ \", \" ++ y.to_string() \
@@ -1673,7 +1674,7 @@ mod tests {
            in \"list with \" ++ (rest_count + 2).to_string() ++ \" elements, first two sum: \" ++ sum.to_string() \
          } \
          \\ _ -> \"not a list\"",
-    );
+        );
 
         assert!(
             result.is_some(),

--- a/optd-dsl/src/parser/function.rs
+++ b/optd-dsl/src/parser/function.rs
@@ -1,7 +1,8 @@
 use chumsky::{
+    Parser,
     error::Simple,
     prelude::{choice, just},
-    select, Parser,
+    select,
 };
 
 use crate::{
@@ -31,8 +32,8 @@ use super::{
 ///
 /// Extern functions are identified by the absence of "=" and body, and must have a return type.
 /// They can be used to represent external implementations like Rust UDFs.
-pub fn function_parser(
-) -> impl Parser<Token, Spanned<Function>, Error = Simple<Token, Span>> + Clone {
+pub fn function_parser()
+-> impl Parser<Token, Spanned<Function>, Error = Simple<Token, Span>> + Clone {
     let annotations = delimited_parser(
         select! { Token::TermIdent(name) => name }
             .map_with_span(Spanned::new)
@@ -127,7 +128,7 @@ mod tests {
         lexer::lex::lex,
         parser::ast::{Expr, Type},
     };
-    use chumsky::{prelude::end, Stream};
+    use chumsky::{Stream, prelude::end};
 
     fn parse_function(input: &str) -> (Option<Spanned<Function>>, Vec<Simple<Token, Span>>) {
         let (tokens, _) = lex(input, "test.txt");

--- a/optd-dsl/src/parser/module.rs
+++ b/optd-dsl/src/parser/module.rs
@@ -1,7 +1,7 @@
 use crate::lexer::tokens::Token;
 use crate::utils::error::CompileError;
 use crate::utils::span::Span;
-use chumsky::{prelude::*, Stream};
+use chumsky::{Stream, prelude::*};
 
 use super::adt::adt_parser;
 use super::ast::{Item, Module};

--- a/optd-dsl/src/parser/pattern.rs
+++ b/optd-dsl/src/parser/pattern.rs
@@ -1,11 +1,12 @@
 use chumsky::{
+    Parser,
     error::Simple,
     prelude::{choice, just, nested_delimiters, recursive},
-    select, Parser,
+    select,
 };
 
 use crate::{
-    lexer::tokens::{Token, ALL_DELIMITERS},
+    lexer::tokens::{ALL_DELIMITERS, Token},
     parser::ast::{Literal, Pattern},
     utils::span::{Span, Spanned},
 };
@@ -101,7 +102,7 @@ pub fn pattern_parser() -> impl Parser<Token, Spanned<Pattern>, Error = Simple<T
 mod tests {
     use super::*;
     use crate::lexer::lex::lex;
-    use chumsky::{prelude::end, Stream};
+    use chumsky::{Stream, prelude::end};
 
     fn parse_pattern(input: &str) -> (Option<Spanned<Pattern>>, Vec<Simple<Token, Span>>) {
         let (tokens, _) = lex(input, "test.txt");

--- a/optd-dsl/src/parser/type.rs
+++ b/optd-dsl/src/parser/type.rs
@@ -1,7 +1,8 @@
 use chumsky::{
+    Parser,
     error::Simple,
     prelude::{choice, just, recursive},
-    select, Parser,
+    select,
 };
 
 use crate::{
@@ -102,7 +103,7 @@ pub fn type_parser() -> impl Parser<Token, Spanned<Type>, Error = Simple<Token, 
 mod tests {
     use super::*;
     use crate::lexer::lex::lex;
-    use chumsky::{prelude::end, Stream};
+    use chumsky::{Stream, prelude::end};
 
     fn parse_type(input: &str) -> Result<Spanned<Type>, Vec<Simple<Token, Span>>> {
         let (tokens, _) = lex(input, "test.txt");

--- a/optd-dsl/src/parser/utils.rs
+++ b/optd-dsl/src/parser/utils.rs
@@ -1,11 +1,12 @@
 use chumsky::{
+    Parser,
     error::Simple,
     prelude::{just, nested_delimiters},
-    select, Parser,
+    select,
 };
 
 use crate::{
-    lexer::tokens::{Token, ALL_DELIMITERS},
+    lexer::tokens::{ALL_DELIMITERS, Token},
     utils::span::{Span, Spanned},
 };
 
@@ -20,8 +21,8 @@ fn field_parser() -> impl Parser<Token, Spanned<Field>, Error = Simple<Token, Sp
         .map_with_span(Spanned::new)
 }
 
-pub(super) fn fields_list_parser(
-) -> impl Parser<Token, Vec<Spanned<Field>>, Error = Simple<Token, Span>> + Clone {
+pub(super) fn fields_list_parser()
+-> impl Parser<Token, Vec<Spanned<Field>>, Error = Simple<Token, Span>> + Clone {
     field_parser()
         .separated_by(just(Token::Comma))
         .allow_trailing()

--- a/optd-dsl/src/utils/error.rs
+++ b/optd-dsl/src/utils/error.rs
@@ -1,6 +1,6 @@
 use super::span::Span;
 use crate::{
-    analyzer::{r#type::error::TypeError, semantic::error::SemanticError},
+    analyzer::{semantic::error::SemanticError, r#type::error::TypeError},
     lexer::error::LexerError,
     parser::error::ParserError,
 };


### PR DESCRIPTION
## Problem

Bumps the rust edition to [2024](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html).

## Summary of changes

I just ran `cargo fix --edition` for 2024, and there were very few changes needed.

## Rationale

This isn't just about being stale, this would make writing the rule engine SO MUCH easier. Notably async closures would help quite a lot with all of the continuations in the rule engine (the verbosity right now makes it hard to grok). There is basically no hope for someone trying to contribute to the rule engine who doesn't understand how futures in Rust works...

Also once this gets stabilized things become so much nicer: https://github.com/rust-lang/rust/pull/138424 (it would mean we don't have to have the `UnitFuture` type alias and `Box::pin` all of our continuations with the `dyn Trait` coercions).