### PR TITLE
(feat) DSL: add optionals & logical/physical subtypes

### DIFF
--- a/optd-core/src/bridge/from_cir.rs
+++ b/optd-core/src/bridge/from_cir.rs
@@ -65,7 +65,7 @@ pub(crate) fn costed_physical_to_value(plan: PartialPhysicalPlan, cost: Cost) ->
 pub(crate) fn logical_properties_to_value(properties: &LogicalProperties) -> Value {
     match &properties.0 {
         Some(data) => properties_data_to_value(data),
-        None => Value(Null),
+        Option::None => Value(None),
     }
 }
 
@@ -73,7 +73,7 @@ pub(crate) fn logical_properties_to_value(properties: &LogicalProperties) -> Val
 pub(crate) fn physical_properties_to_value(properties: &PhysicalProperties) -> Value {
     match &properties.0 {
         Some(data) => properties_data_to_value(data),
-        None => Value(Null),
+        Option::None => Value(None),
     }
 }
 

--- a/optd-core/src/bridge/from_cir.rs
+++ b/optd-core/src/bridge/from_cir.rs
@@ -14,7 +14,9 @@ pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
     match plan {
         PartialLogicalPlan::UnMaterialized(group_id) => {
             // For unmaterialized logical operators, we create a `Value` with the group ID.
-            Value(Logical(LogicalOp(UnMaterialized(hir::GroupId(group_id.0)))))
+            Value(Logical(LogicalOp::logical(UnMaterialized(hir::GroupId(
+                group_id.0,
+            )))))
         }
         PartialLogicalPlan::Materialized(node) => {
             // For materialized logical operators, we create a `Value` with the operator data.
@@ -24,7 +26,7 @@ pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
                 children: convert_children_to_values(&node.children, partial_logical_to_value),
             };
 
-            Value(Logical(LogicalOp(Materialized(operator))))
+            Value(Logical(LogicalOp::logical(Materialized(operator))))
         }
     }
 }
@@ -35,7 +37,7 @@ pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
         PartialPhysicalPlan::UnMaterialized(goal) => {
             // For unmaterialized physical operators, we create a `Value` with the goal
             let hir_goal = cir_goal_to_hir(goal);
-            Value(Physical(PhysicalOp(UnMaterialized(hir_goal))))
+            Value(Physical(PhysicalOp::physical(UnMaterialized(hir_goal))))
         }
         PartialPhysicalPlan::Materialized(node) => {
             // For materialized physical operators, we create a Value with the operator data
@@ -45,7 +47,7 @@ pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
                 children: convert_children_to_values(&node.children, partial_physical_to_value),
             };
 
-            Value(Physical(PhysicalOp(Materialized(operator))))
+            Value(Physical(PhysicalOp::physical(Materialized(operator))))
         }
     }
 }

--- a/optd-core/src/bridge/from_cir.rs
+++ b/optd-core/src/bridge/from_cir.rs
@@ -14,9 +14,7 @@ pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
     match plan {
         PartialLogicalPlan::UnMaterialized(group_id) => {
             // For unmaterialized logical operators, we create a `Value` with the group ID.
-            Value(Logical(LogicalOp::logical(UnMaterialized(hir::GroupId(
-                group_id.0,
-            )))))
+            Value(Logical(UnMaterialized(hir::GroupId(group_id.0))))
         }
         PartialLogicalPlan::Materialized(node) => {
             // For materialized logical operators, we create a `Value` with the operator data.
@@ -26,7 +24,7 @@ pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
                 children: convert_children_to_values(&node.children, partial_logical_to_value),
             };
 
-            Value(Logical(LogicalOp::logical(Materialized(operator))))
+            Value(Logical(Materialized(LogicalOp::logical(operator))))
         }
     }
 }
@@ -37,7 +35,7 @@ pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
         PartialPhysicalPlan::UnMaterialized(goal) => {
             // For unmaterialized physical operators, we create a `Value` with the goal
             let hir_goal = cir_goal_to_hir(goal);
-            Value(Physical(PhysicalOp::physical(UnMaterialized(hir_goal))))
+            Value(Physical(UnMaterialized(hir_goal)))
         }
         PartialPhysicalPlan::Materialized(node) => {
             // For materialized physical operators, we create a Value with the operator data
@@ -47,7 +45,7 @@ pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
                 children: convert_children_to_values(&node.children, partial_physical_to_value),
             };
 
-            Value(Physical(PhysicalOp::physical(Materialized(operator))))
+            Value(Physical(Materialized(PhysicalOp::physical(operator))))
         }
     }
 }

--- a/optd-core/src/bridge/into_cir.rs
+++ b/optd-core/src/bridge/into_cir.rs
@@ -15,14 +15,17 @@ use std::sync::Arc;
 /// Panics if the [`Value`] is not a [`Logical`] variant.
 pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
     match &value.0 {
-        Logical(logical_op) => match &logical_op.operator {
+        Logical(logical_op) => match logical_op {
             UnMaterialized(group_id) => {
                 PartialLogicalPlan::UnMaterialized(hir_group_id_to_cir(group_id))
             }
-            Materialized(op) => PartialLogicalPlan::Materialized(Operator {
-                tag: op.tag.clone(),
-                data: convert_values_to_operator_data(&op.data),
-                children: convert_values_to_children(&op.children, value_to_partial_logical),
+            Materialized(log_op) => PartialLogicalPlan::Materialized(Operator {
+                tag: log_op.operator.tag.clone(),
+                data: convert_values_to_operator_data(&log_op.operator.data),
+                children: convert_values_to_children(
+                    &log_op.operator.children,
+                    value_to_partial_logical,
+                ),
             }),
         },
         _ => panic!("Expected Logical CoreData variant, found: {:?}", value.0),
@@ -36,14 +39,17 @@ pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
 /// Panics if the [`Value`] is not a [`Physical`] variant.
 pub(crate) fn value_to_partial_physical(value: &Value) -> PartialPhysicalPlan {
     match &value.0 {
-        Physical(physical_op) => match &physical_op.operator {
+        Physical(physical_op) => match physical_op {
             UnMaterialized(hir_goal) => {
                 PartialPhysicalPlan::UnMaterialized(hir_goal_to_cir(hir_goal))
             }
-            Materialized(op) => PartialPhysicalPlan::Materialized(Operator {
-                tag: op.tag.clone(),
-                data: convert_values_to_operator_data(&op.data),
-                children: convert_values_to_children(&op.children, value_to_partial_physical),
+            Materialized(phys_op) => PartialPhysicalPlan::Materialized(Operator {
+                tag: phys_op.operator.tag.clone(),
+                data: convert_values_to_operator_data(&phys_op.operator.data),
+                children: convert_values_to_children(
+                    &phys_op.operator.children,
+                    value_to_partial_physical,
+                ),
             }),
         },
         _ => panic!("Expected Physical CoreData variant, found: {:?}", value.0),
@@ -103,14 +109,14 @@ pub(crate) fn hir_goal_to_cir(hir_goal: &hir::Goal) -> Goal {
 /// [`Materialized`] variant.
 fn value_to_logical(value: &Value) -> LogicalPlan {
     match &value.0 {
-        Logical(logical_op) => match &logical_op.operator {
+        Logical(logical_op) => match logical_op {
             UnMaterialized(_) => {
                 panic!("Cannot convert UnMaterialized LogicalOperator to LogicalPlan")
             }
-            Materialized(op) => LogicalPlan(Operator {
-                tag: op.tag.clone(),
-                data: convert_values_to_operator_data(&op.data),
-                children: convert_values_to_children(&op.children, value_to_logical),
+            Materialized(log_op) => LogicalPlan(Operator {
+                tag: log_op.operator.tag.clone(),
+                data: convert_values_to_operator_data(&log_op.operator.data),
+                children: convert_values_to_children(&log_op.operator.children, value_to_logical),
             }),
         },
         _ => panic!("Expected Logical CoreData variant, found: {:?}", value.0),

--- a/optd-core/src/bridge/into_cir.rs
+++ b/optd-core/src/bridge/into_cir.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 /// Panics if the [`Value`] is not a [`Logical`] variant.
 pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
     match &value.0 {
-        Logical(logical_op) => match &logical_op.0 {
+        Logical(logical_op) => match &logical_op.operator {
             UnMaterialized(group_id) => {
                 PartialLogicalPlan::UnMaterialized(hir_group_id_to_cir(group_id))
             }
@@ -36,7 +36,7 @@ pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
 /// Panics if the [`Value`] is not a [`Physical`] variant.
 pub(crate) fn value_to_partial_physical(value: &Value) -> PartialPhysicalPlan {
     match &value.0 {
-        Physical(physical_op) => match &physical_op.0 {
+        Physical(physical_op) => match &physical_op.operator {
             UnMaterialized(hir_goal) => {
                 PartialPhysicalPlan::UnMaterialized(hir_goal_to_cir(hir_goal))
             }
@@ -103,7 +103,7 @@ pub(crate) fn hir_goal_to_cir(hir_goal: &hir::Goal) -> Goal {
 /// [`Materialized`] variant.
 fn value_to_logical(value: &Value) -> LogicalPlan {
     match &value.0 {
-        Logical(logical_op) => match &logical_op.0 {
+        Logical(logical_op) => match &logical_op.operator {
             UnMaterialized(_) => {
                 panic!("Cannot convert UnMaterialized LogicalOperator to LogicalPlan")
             }

--- a/optd-core/src/bridge/into_cir.rs
+++ b/optd-core/src/bridge/into_cir.rs
@@ -1,4 +1,5 @@
 //! Converts HIR [`Value`]s into optd's type representations (CIR).
+
 use crate::cir::*;
 use Child::*;
 use CoreData::*;
@@ -64,7 +65,7 @@ pub(crate) fn value_to_cost(value: &Value) -> Cost {
 /// Converts an HIR properties [`Value`] into a CIR [`LogicalProperties`].
 pub(crate) fn value_to_logical_properties(properties_value: &Value) -> LogicalProperties {
     match &properties_value.0 {
-        Null => LogicalProperties(None),
+        None => LogicalProperties(Option::None),
         _ => LogicalProperties(Some(value_to_properties_data(properties_value))),
     }
 }
@@ -72,7 +73,7 @@ pub(crate) fn value_to_logical_properties(properties_value: &Value) -> LogicalPr
 /// Convert an HIR properties [`Value`] into a CIR [`PhysicalProperties`].
 fn value_to_physical_properties(properties_value: &Value) -> PhysicalProperties {
     match &properties_value.0 {
-        Null => PhysicalProperties(None),
+        None => PhysicalProperties(Option::None),
         _ => PhysicalProperties(Some(value_to_properties_data(properties_value))),
     }
 }

--- a/optd-dsl/src/analyzer/hir.rs
+++ b/optd-dsl/src/analyzer/hir.rs
@@ -89,7 +89,7 @@ pub struct Operator<T> {
 /// materialized as a concrete operator or referenced by a group ID in the optimizer.
 #[derive(Debug, Clone)]
 pub struct LogicalOp<T> {
-    pub operator: Materializable<Operator<T>, GroupId>,
+    pub operator: Operator<T>,
     pub group_id: Option<GroupId>,
 }
 
@@ -98,7 +98,7 @@ impl<T> LogicalOp<T> {
     ///
     /// Used for representing operators that are not yet assigned to a group
     /// in the optimizer.
-    pub fn logical(operator: Materializable<Operator<T>, GroupId>) -> Self {
+    pub fn logical(operator: Operator<T>) -> Self {
         Self {
             operator,
             group_id: None,
@@ -109,10 +109,7 @@ impl<T> LogicalOp<T> {
     ///
     /// Used for representing operators that have been stored in the optimizer
     /// with a specific group identity.
-    pub fn stored_logical(
-        operator: Materializable<Operator<T>, GroupId>,
-        group_id: GroupId,
-    ) -> Self {
+    pub fn stored_logical(operator: Operator<T>, group_id: GroupId) -> Self {
         Self {
             operator,
             group_id: Some(group_id),
@@ -126,7 +123,7 @@ impl<T> LogicalOp<T> {
 /// physical properties, either materialized as a concrete operator or as a physical goal.
 #[derive(Debug, Clone)]
 pub struct PhysicalOp<T> {
-    pub operator: Materializable<Operator<T>, Goal>,
+    pub operator: Operator<T>,
     pub goal: Option<Goal>,
     pub cost: Option<Box<Value>>,
 }
@@ -136,7 +133,7 @@ impl<T> PhysicalOp<T> {
     ///
     /// Used for representing physical operators that are not yet part of the
     /// optimization process.
-    pub fn physical(operator: Materializable<Operator<T>, Goal>) -> Self {
+    pub fn physical(operator: Operator<T>) -> Self {
         Self {
             operator,
             goal: None,
@@ -148,7 +145,7 @@ impl<T> PhysicalOp<T> {
     ///
     /// Used for representing physical operators that have been stored in the optimizer
     /// with a specific goal but haven't been costed yet.
-    pub fn stored_physical(operator: Materializable<Operator<T>, Goal>, goal: Goal) -> Self {
+    pub fn stored_physical(operator: Operator<T>, goal: Goal) -> Self {
         Self {
             operator,
             goal: Some(goal),
@@ -159,11 +156,7 @@ impl<T> PhysicalOp<T> {
     /// Creates a new physical operator with both goal and cost information
     ///
     /// Used for representing fully optimized physical operators with computed cost.
-    pub fn costed_physical(
-        operator: Materializable<Operator<T>, Goal>,
-        goal: Goal,
-        cost: Value,
-    ) -> Self {
+    pub fn costed_physical(operator: Operator<T>, goal: Goal, cost: Value) -> Self {
         Self {
             operator,
             goal: Some(goal),
@@ -190,9 +183,9 @@ pub enum CoreData<T> {
     /// Error representation
     Fail(Box<T>),
     /// Logical query operators
-    Logical(LogicalOp<T>),
+    Logical(Materializable<LogicalOp<T>, GroupId>),
     /// Physical query operators
-    Physical(PhysicalOp<T>),
+    Physical(Materializable<PhysicalOp<T>, Goal>),
     /// The None value
     None,
 }

--- a/optd-dsl/src/analyzer/hir.rs
+++ b/optd-dsl/src/analyzer/hir.rs
@@ -118,8 +118,8 @@ pub enum CoreData<T> {
     Logical(LogicalOp<T>),
     /// Physical query operators
     Physical(PhysicalOp<T>),
-    /// The null value
-    Null,
+    /// The None value
+    None,
 }
 
 /// Expression nodes in the HIR

--- a/optd-dsl/src/analyzer/hir.rs
+++ b/optd-dsl/src/analyzer/hir.rs
@@ -88,14 +88,89 @@ pub struct Operator<T> {
 /// Represents a logical relational algebra operation that can be either
 /// materialized as a concrete operator or referenced by a group ID in the optimizer.
 #[derive(Debug, Clone)]
-pub struct LogicalOp<T>(pub Materializable<Operator<T>, GroupId>);
+pub struct LogicalOp<T> {
+    pub operator: Materializable<Operator<T>, GroupId>,
+    pub group_id: Option<GroupId>,
+}
+
+impl<T> LogicalOp<T> {
+    /// Creates a new logical operator without a group ID
+    ///
+    /// Used for representing operators that are not yet assigned to a group
+    /// in the optimizer.
+    pub fn logical(operator: Materializable<Operator<T>, GroupId>) -> Self {
+        Self {
+            operator,
+            group_id: None,
+        }
+    }
+
+    /// Creates a new logical operator with an assigned group ID
+    ///
+    /// Used for representing operators that have been stored in the optimizer
+    /// with a specific group identity.
+    pub fn stored_logical(
+        operator: Materializable<Operator<T>, GroupId>,
+        group_id: GroupId,
+    ) -> Self {
+        Self {
+            operator,
+            group_id: Some(group_id),
+        }
+    }
+}
 
 /// Physical operator in the query plan
 ///
 /// Represents an executable implementation of a logical operation with specific
 /// physical properties, either materialized as a concrete operator or as a physical goal.
 #[derive(Debug, Clone)]
-pub struct PhysicalOp<T>(pub Materializable<Operator<T>, Goal>);
+pub struct PhysicalOp<T> {
+    pub operator: Materializable<Operator<T>, Goal>,
+    pub goal: Option<Goal>,
+    pub cost: Option<Box<Value>>,
+}
+
+impl<T> PhysicalOp<T> {
+    /// Creates a new physical operator without goal or cost information
+    ///
+    /// Used for representing physical operators that are not yet part of the
+    /// optimization process.
+    pub fn physical(operator: Materializable<Operator<T>, Goal>) -> Self {
+        Self {
+            operator,
+            goal: None,
+            cost: None,
+        }
+    }
+
+    /// Creates a new physical operator with goal but without cost information
+    ///
+    /// Used for representing physical operators that have been stored in the optimizer
+    /// with a specific goal but haven't been costed yet.
+    pub fn stored_physical(operator: Materializable<Operator<T>, Goal>, goal: Goal) -> Self {
+        Self {
+            operator,
+            goal: Some(goal),
+            cost: None,
+        }
+    }
+
+    /// Creates a new physical operator with both goal and cost information
+    ///
+    /// Used for representing fully optimized physical operators with computed cost.
+    pub fn costed_physical(
+        operator: Materializable<Operator<T>, Goal>,
+        goal: Goal,
+        cost: Value,
+    ) -> Self {
+        Self {
+            operator,
+            goal: Some(goal),
+            cost: Some(cost.into()),
+        }
+    }
+}
 
 /// Core data structures shared across the system
 #[derive(Debug, Clone)]

--- a/optd-dsl/src/cli/basic.op
+++ b/optd-dsl/src/cli/basic.op
@@ -1,9 +1,9 @@
-data LogicalProps(schema_len: )
+data LogicalProps(schema_len: I64)
 
 data Scalar =
-    | ColumnRef(idx: Int64)
+    | ColumnRef(idx: I64)
     | Literal =
-        | IntLiteral(value: Int64)
+        | IntLiteral(value: I64)
         | StringLiteral(value: String)
         | BoolLiteral(value: Bool)
         \ NullLiteral
@@ -92,16 +92,16 @@ data JoinType =
     \ Semi
 
 [rust]
-fn (expr: Scalar) apply_children(f: Scalar => Scalar) = ()
+fn (expr: Scalar) apply_children(f: Scalar -> Scalar) = None
 
-fn (pred: Predicate) remap(map: {I64 : I64)}) =
+fn (pred: Predicate) remap(map: {I64 : I64}) =
     match predicate
         | ColumnRef(idx) -> ColumnRef(map(idx))
         \ _ -> predicate.apply_children(child -> rewrite_column_refs(child, map))
     
 [rule]
-fn (expr: Logical) join_commute = match expr
-    \ Join(left, right, Inner, cond) =>
+fn (expr: Logical) join_commute: Logical? = match expr
+    \ Join(left, right, Inner, cond) ->
         let 
             right_indices = 0.right.schema_len,
             left_indices = 0..left.schema_len,

--- a/optd-dsl/src/engine/eval/core.rs
+++ b/optd-dsl/src/engine/eval/core.rs
@@ -42,9 +42,9 @@ where
         Fail(msg) => evaluate_fail(*msg, engine, k).await,
         Logical(op) => evaluate_logical_operator(op, engine, k).await,
         Physical(op) => evaluate_physical_operator(op, engine, k).await,
-        Null => {
+        None => {
             // Directly continue with null value.
-            k(Value(Null)).await
+            k(Value(None)).await
         }
     }
 }
@@ -396,14 +396,14 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a null expression
-        let null_expr = Arc::new(Expr::CoreExpr(CoreData::Null));
+        let null_expr = Arc::new(Expr::CoreExpr(CoreData::None));
 
         let results = evaluate_and_collect(null_expr, engine, harness).await;
 
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Null => {
+            CoreData::None => {
                 // Successfully evaluated to null
             }
             _ => panic!("Expected null"),

--- a/optd-dsl/src/engine/eval/match.rs
+++ b/optd-dsl/src/engine/eval/match.rs
@@ -157,7 +157,13 @@ where
 
                 match_struct_pattern(pat_name, pat_fields, val_fields, ctx, k).await
             }
-            (Operator(op_pattern), CoreData::Logical(LogicalOp(Materialized(operator)))) => {
+            (
+                Operator(op_pattern),
+                CoreData::Logical(LogicalOp {
+                    operator: Materialized(operator),
+                    ..
+                }),
+            ) => {
                 if op_pattern.tag != operator.tag
                     || op_pattern.data.len() != operator.data.len()
                     || op_pattern.children.len() != operator.children.len()
@@ -167,7 +173,13 @@ where
 
                 match_materialized_operator(true, op_pattern, operator.clone(), ctx, k).await
             }
-            (Operator(op_pattern), CoreData::Physical(PhysicalOp(Materialized(operator)))) => {
+            (
+                Operator(op_pattern),
+                CoreData::Physical(PhysicalOp {
+                    operator: Materialized(operator),
+                    ..
+                }),
+            ) => {
                 if op_pattern.tag != operator.tag
                     || op_pattern.data.len() != operator.data.len()
                     || op_pattern.children.len() != operator.children.len()
@@ -178,7 +190,13 @@ where
                 match_materialized_operator(false, op_pattern, operator.clone(), ctx, k).await
             }
             // Unmaterialized operators.
-            (Operator(op_pattern), CoreData::Logical(LogicalOp(UnMaterialized(group_id)))) => {
+            (
+                Operator(op_pattern),
+                CoreData::Logical(LogicalOp {
+                    operator: UnMaterialized(group_id),
+                    ..
+                }),
+            ) => {
                 // Yield the group id back to the caller and provide a callback to match expanded value against the pattern.
                 EngineResponse::YieldGroup(
                     *group_id,
@@ -189,7 +207,13 @@ where
                     }),
                 )
             }
-            (Operator(op_pattern), CoreData::Physical(PhysicalOp(UnMaterialized(goal)))) => {
+            (
+                Operator(op_pattern),
+                CoreData::Physical(PhysicalOp {
+                    operator: UnMaterialized(goal),
+                    ..
+                }),
+            ) => {
                 // Yield the goal back to the caller and provide a callback to match expanded value against the pattern.
                 EngineResponse::YieldGoal(
                     goal.clone(),
@@ -404,9 +428,11 @@ where
 
                 // Create appropriate value type based on original_value.
                 let new_value = if is_logical {
-                    Value(CoreData::Logical(LogicalOp(Materialized(new_op))))
+                    Value(CoreData::Logical(LogicalOp::logical(Materialized(new_op))))
                 } else {
-                    Value(CoreData::Physical(PhysicalOp(Materialized(new_op))))
+                    Value(CoreData::Physical(PhysicalOp::physical(Materialized(
+                        new_op,
+                    ))))
                 };
 
                 if all_matched {
@@ -527,6 +553,7 @@ mod tests {
         },
         engine::test_utils::TestHarness,
     };
+    use Materializable::*;
     use std::sync::Arc;
 
     /// Test simple pattern matching with literals
@@ -732,9 +759,7 @@ mod tests {
             ],
         };
 
-        let logical_op_value = Value(CoreData::Logical(LogicalOp(Materializable::Materialized(
-            op,
-        ))));
+        let logical_op_value = Value(CoreData::Logical(LogicalOp::logical(Materialized(op))));
         let logical_op_expr = Arc::new(Expr::CoreVal(logical_op_value.clone()));
 
         // Create a match expression:
@@ -836,8 +861,8 @@ mod tests {
         harness.register_group(test_group_id, materialized_join);
 
         // Create an unmaterialized logical operator
-        let unmaterialized_logical_op = Value(CoreData::Logical(LogicalOp(
-            Materializable::UnMaterialized(test_group_id),
+        let unmaterialized_logical_op = Value(CoreData::Logical(LogicalOp::logical(
+            UnMaterialized(test_group_id),
         )));
 
         let unmaterialized_expr = Arc::new(Expr::CoreVal(unmaterialized_logical_op));
@@ -949,8 +974,8 @@ mod tests {
         harness.register_goal(&test_goal, materialized_hash_join);
 
         // Create an unmaterialized physical operator with the goal
-        let unmaterialized_physical_op = Value(CoreData::Physical(PhysicalOp(
-            Materializable::UnMaterialized(test_goal.clone()),
+        let unmaterialized_physical_op = Value(CoreData::Physical(PhysicalOp::physical(
+            UnMaterialized(test_goal),
         )));
 
         let unmaterialized_expr = Arc::new(Expr::CoreVal(unmaterialized_physical_op));
@@ -1393,12 +1418,12 @@ mod tests {
                 lit_val(string("left.id = right.id")),
             ],
             vec![
-                Value(CoreData::Logical(LogicalOp(
-                    Materializable::UnMaterialized(group_id_1),
-                ))),
-                Value(CoreData::Logical(LogicalOp(
-                    Materializable::UnMaterialized(group_id_2),
-                ))),
+                Value(CoreData::Logical(LogicalOp::logical(UnMaterialized(
+                    group_id_1,
+                )))),
+                Value(CoreData::Logical(LogicalOp::logical(UnMaterialized(
+                    group_id_2,
+                )))),
             ],
         );
 

--- a/optd-dsl/src/engine/eval/match.rs
+++ b/optd-dsl/src/engine/eval/match.rs
@@ -139,6 +139,7 @@ where
                 k((value, context_opt)).await
             }
             (EmptyArray, CoreData::Array(arr)) if arr.is_empty() => k((value, Some(ctx))).await,
+
             // Complex patterns.
             (Bind(ident, inner_pattern), _) => {
                 match_bind_pattern(value.clone(), ident, *inner_pattern, ctx, k).await
@@ -157,46 +158,34 @@ where
 
                 match_struct_pattern(pat_name, pat_fields, val_fields, ctx, k).await
             }
-            (
-                Operator(op_pattern),
-                CoreData::Logical(LogicalOp {
-                    operator: Materialized(operator),
-                    ..
-                }),
-            ) => {
-                if op_pattern.tag != operator.tag
-                    || op_pattern.data.len() != operator.data.len()
-                    || op_pattern.children.len() != operator.children.len()
+
+            // Materialized logical operators
+            (Operator(op_pattern), CoreData::Logical(Materialized(log_op))) => {
+                if op_pattern.tag != log_op.operator.tag
+                    || op_pattern.data.len() != log_op.operator.data.len()
+                    || op_pattern.children.len() != log_op.operator.children.len()
                 {
                     return k((value, None)).await;
                 }
 
-                match_materialized_operator(true, op_pattern, operator.clone(), ctx, k).await
+                match_materialized_operator(true, op_pattern, log_op.operator.clone(), ctx, k).await
             }
-            (
-                Operator(op_pattern),
-                CoreData::Physical(PhysicalOp {
-                    operator: Materialized(operator),
-                    ..
-                }),
-            ) => {
-                if op_pattern.tag != operator.tag
-                    || op_pattern.data.len() != operator.data.len()
-                    || op_pattern.children.len() != operator.children.len()
+
+            // Materialized physical operators
+            (Operator(op_pattern), CoreData::Physical(Materialized(phys_op))) => {
+                if op_pattern.tag != phys_op.operator.tag
+                    || op_pattern.data.len() != phys_op.operator.data.len()
+                    || op_pattern.children.len() != phys_op.operator.children.len()
                 {
                     return k((value, None)).await;
                 }
 
-                match_materialized_operator(false, op_pattern, operator.clone(), ctx, k).await
+                match_materialized_operator(false, op_pattern, phys_op.operator.clone(), ctx, k)
+                    .await
             }
-            // Unmaterialized operators.
-            (
-                Operator(op_pattern),
-                CoreData::Logical(LogicalOp {
-                    operator: UnMaterialized(group_id),
-                    ..
-                }),
-            ) => {
+
+            // Unmaterialized logical operators
+            (Operator(op_pattern), CoreData::Logical(UnMaterialized(group_id))) => {
                 // Yield the group id back to the caller and provide a callback to match expanded value against the pattern.
                 EngineResponse::YieldGroup(
                     *group_id,
@@ -207,13 +196,9 @@ where
                     }),
                 )
             }
-            (
-                Operator(op_pattern),
-                CoreData::Physical(PhysicalOp {
-                    operator: UnMaterialized(goal),
-                    ..
-                }),
-            ) => {
+
+            // Unmaterialized physical operators
+            (Operator(op_pattern), CoreData::Physical(UnMaterialized(goal))) => {
                 // Yield the goal back to the caller and provide a callback to match expanded value against the pattern.
                 EngineResponse::YieldGoal(
                     goal.clone(),
@@ -224,6 +209,7 @@ where
                     }),
                 )
             }
+
             // No match for other combinations.
             _ => k((value, None)).await,
         }
@@ -409,7 +395,7 @@ where
         all_values,
         ctx.clone(),
         Arc::new(move |results| {
-            Box::pin(capture!([ctx, operator, k], async move {
+            Box::pin(capture!([ctx, operator, is_logical, k], async move {
                 // Check if all components matched successfully.
                 let all_matched = results.iter().all(|(_, ctx_opt)| ctx_opt.is_some());
 
@@ -428,11 +414,11 @@ where
 
                 // Create appropriate value type based on original_value.
                 let new_value = if is_logical {
-                    Value(CoreData::Logical(LogicalOp::logical(Materialized(new_op))))
+                    let log_op = LogicalOp::logical(new_op);
+                    Value(CoreData::Logical(Materialized(log_op)))
                 } else {
-                    Value(CoreData::Physical(PhysicalOp::physical(Materialized(
-                        new_op,
-                    ))))
+                    let phys_op = PhysicalOp::physical(new_op);
+                    Value(CoreData::Physical(Materialized(phys_op)))
                 };
 
                 if all_matched {
@@ -548,7 +534,7 @@ mod tests {
             context::Context,
             hir::{
                 BinOp, CoreData, Expr, FunKind, Goal, GroupId, Literal, LogicalOp, Materializable,
-                Operator, PhysicalOp, Value,
+                Operator, Value,
             },
         },
         engine::test_utils::TestHarness,
@@ -759,7 +745,7 @@ mod tests {
             ],
         };
 
-        let logical_op_value = Value(CoreData::Logical(LogicalOp::logical(Materialized(op))));
+        let logical_op_value = Value(CoreData::Logical(Materialized(LogicalOp::logical(op))));
         let logical_op_expr = Arc::new(Expr::CoreVal(logical_op_value.clone()));
 
         // Create a match expression:
@@ -861,9 +847,7 @@ mod tests {
         harness.register_group(test_group_id, materialized_join);
 
         // Create an unmaterialized logical operator
-        let unmaterialized_logical_op = Value(CoreData::Logical(LogicalOp::logical(
-            UnMaterialized(test_group_id),
-        )));
+        let unmaterialized_logical_op = Value(CoreData::Logical(UnMaterialized(test_group_id)));
 
         let unmaterialized_expr = Arc::new(Expr::CoreVal(unmaterialized_logical_op));
 
@@ -974,9 +958,7 @@ mod tests {
         harness.register_goal(&test_goal, materialized_hash_join);
 
         // Create an unmaterialized physical operator with the goal
-        let unmaterialized_physical_op = Value(CoreData::Physical(PhysicalOp::physical(
-            UnMaterialized(test_goal),
-        )));
+        let unmaterialized_physical_op = Value(CoreData::Physical(UnMaterialized(test_goal)));
 
         let unmaterialized_expr = Arc::new(Expr::CoreVal(unmaterialized_physical_op));
 
@@ -1418,12 +1400,8 @@ mod tests {
                 lit_val(string("left.id = right.id")),
             ],
             vec![
-                Value(CoreData::Logical(LogicalOp::logical(UnMaterialized(
-                    group_id_1,
-                )))),
-                Value(CoreData::Logical(LogicalOp::logical(UnMaterialized(
-                    group_id_2,
-                )))),
+                Value(CoreData::Logical(UnMaterialized(group_id_1))),
+                Value(CoreData::Logical(UnMaterialized(group_id_2))),
             ],
         );
 

--- a/optd-dsl/src/engine/eval/operator.rs
+++ b/optd-dsl/src/engine/eval/operator.rs
@@ -1,5 +1,5 @@
 use crate::analyzer::hir::{
-    CoreData, Expr, LogicalOp, Materializable, Operator, PhysicalOp, Value,
+    CoreData, Expr, Goal, GroupId, LogicalOp, Materializable, Operator, PhysicalOp, Value,
 };
 use crate::engine::utils::evaluate_sequence;
 use crate::engine::{Continuation, EngineResponse};
@@ -16,32 +16,32 @@ use std::sync::Arc;
 /// * `engine` - The evaluation engine.
 /// * `k` - The continuation to receive evaluation results.
 pub(crate) async fn evaluate_logical_operator<O>(
-    op: LogicalOp<Arc<Expr>>,
+    op: Materializable<LogicalOp<Arc<Expr>>, GroupId>,
     engine: Engine,
     k: Continuation<Value, EngineResponse<O>>,
 ) -> EngineResponse<O>
 where
     O: Send + 'static,
 {
-    match op.operator {
+    match op {
         // For unmaterialized operators, directly call the continuation with the unmaterialized
         // value.
         UnMaterialized(group_id) => {
-            let result = Value(Logical(LogicalOp::logical(UnMaterialized(group_id))));
+            let result = Value(Logical(UnMaterialized(group_id)));
             k(result).await
         }
         // For materialized operators, evaluate all parts and construct the result.
-        Materialized(op) => {
+        Materialized(log_op) => {
             evaluate_operator(
-                op.data,
-                op.children,
-                op.tag,
+                log_op.operator.data,
+                log_op.operator.children,
+                log_op.operator.tag,
                 engine,
                 Arc::new(move |constructed_op| {
                     Box::pin(capture!([k], async move {
                         // Wrap the constructed operator in the logical operator structure
-                        let result =
-                            Value(Logical(LogicalOp::logical(Materialized(constructed_op))));
+                        let log_op = LogicalOp::logical(constructed_op);
+                        let result = Value(Logical(Materialized(log_op)));
                         k(result).await
                     }))
                 }),
@@ -59,32 +59,30 @@ where
 /// * `engine` - The evaluation engine.
 /// * `k` - The continuation to receive evaluation results.
 pub(crate) async fn evaluate_physical_operator<O>(
-    op: PhysicalOp<Arc<Expr>>,
+    op: Materializable<PhysicalOp<Arc<Expr>>, Goal>,
     engine: Engine,
     k: Continuation<Value, EngineResponse<O>>,
 ) -> EngineResponse<O>
 where
     O: Send + 'static,
 {
-    match op.operator {
+    match op {
         // For unmaterialized operators, continue with the unmaterialized value.
         UnMaterialized(physical_goal) => {
-            let result = Value(Physical(PhysicalOp::physical(UnMaterialized(
-                physical_goal,
-            ))));
+            let result = Value(Physical(UnMaterialized(physical_goal)));
             k(result).await
         }
         // For materialized operators, evaluate all parts and construct the result.
-        Materialized(op) => {
+        Materialized(phys_op) => {
             evaluate_operator(
-                op.data,
-                op.children,
-                op.tag,
+                phys_op.operator.data,
+                phys_op.operator.children,
+                phys_op.operator.tag,
                 engine,
                 Arc::new(move |constructed_op| {
                     Box::pin(capture!([k], async move {
-                        let result =
-                            Value(Physical(PhysicalOp::physical(Materialized(constructed_op))));
+                        let phys_op = PhysicalOp::physical(constructed_op);
+                        let result = Value(Physical(Materialized(phys_op)));
                         k(result).await
                     }))
                 }),
@@ -171,7 +169,7 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a materialized logical operator expression with nested expressions to evaluate
-        let op = LogicalOp::logical(Materializable::Materialized(Operator {
+        let log_op = LogicalOp::logical(Operator {
             tag: "Join".to_string(),
             data: vec![
                 lit_expr(string("inner")),
@@ -185,10 +183,12 @@ mod tests {
                 Arc::new(Expr::CoreExpr(CoreData::Literal(string("orders")))),
                 Arc::new(Expr::CoreExpr(CoreData::Literal(string("lineitem")))),
             ],
-        }));
+        });
 
         // Create the expression to evaluate
-        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(op)));
+        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(
+            Materializable::Materialized(log_op),
+        )));
 
         // Evaluate the expression
         let results = evaluate_and_collect(logical_op_expr, engine, harness).await;
@@ -196,46 +196,41 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Logical(op) => {
-                match &op.operator {
-                    Materializable::Materialized(op) => {
-                        // Check tag
-                        assert_eq!(op.tag, "Join");
+            CoreData::Logical(Materializable::Materialized(log_op)) => {
+                // Check tag
+                assert_eq!(log_op.operator.tag, "Join");
 
-                        // Check data - should have "inner" and 15
-                        assert_eq!(op.data.len(), 2);
-                        match &op.data[0].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("inner".to_string()));
-                            }
-                            _ => panic!("Expected string literal"),
-                        }
-                        match &op.data[1].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::Int64(15));
-                            }
-                            _ => panic!("Expected integer literal"),
-                        }
-
-                        // Check children - should have "orders" and "lineitem"
-                        assert_eq!(op.children.len(), 2);
-                        match &op.children[0].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("orders".to_string()));
-                            }
-                            _ => panic!("Expected string literal"),
-                        }
-                        match &op.children[1].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("lineitem".to_string()));
-                            }
-                            _ => panic!("Expected string literal"),
-                        }
+                // Check data - should have "inner" and 15
+                assert_eq!(log_op.operator.data.len(), 2);
+                match &log_op.operator.data[0].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("inner".to_string()));
                     }
-                    _ => panic!("Expected materialized logical operator"),
+                    _ => panic!("Expected string literal"),
+                }
+                match &log_op.operator.data[1].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::Int64(15));
+                    }
+                    _ => panic!("Expected integer literal"),
+                }
+
+                // Check children - should have "orders" and "lineitem"
+                assert_eq!(log_op.operator.children.len(), 2);
+                match &log_op.operator.children[0].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("orders".to_string()));
+                    }
+                    _ => panic!("Expected string literal"),
+                }
+                match &log_op.operator.children[1].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("lineitem".to_string()));
+                    }
+                    _ => panic!("Expected string literal"),
                 }
             }
-            _ => panic!("Expected logical operator"),
+            _ => panic!("Expected materialized logical operator"),
         }
     }
 
@@ -248,10 +243,11 @@ mod tests {
 
         // Create an unmaterialized logical operator with a group ID
         let group_id = GroupId(42);
-        let op = LogicalOp::logical(Materializable::UnMaterialized(group_id));
 
         // Create the expression to evaluate
-        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(op)));
+        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(
+            Materializable::UnMaterialized(group_id),
+        )));
 
         // Evaluate the expression
         let results = evaluate_and_collect(logical_op_expr, engine, harness).await;
@@ -259,16 +255,11 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Logical(op) => {
-                match &op.operator {
-                    Materializable::UnMaterialized(id) => {
-                        // Check that the group ID is preserved
-                        assert_eq!(*id, group_id);
-                    }
-                    _ => panic!("Expected unmaterialized logical operator"),
-                }
+            CoreData::Logical(Materializable::UnMaterialized(id)) => {
+                // Check that the group ID is preserved
+                assert_eq!(*id, group_id);
             }
-            _ => panic!("Expected logical operator"),
+            _ => panic!("Expected unmaterialized logical operator"),
         }
     }
 
@@ -280,7 +271,7 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a materialized physical operator expression with nested expressions to evaluate
-        let op = PhysicalOp::physical(Materializable::Materialized(Operator {
+        let phys_op = PhysicalOp::physical(Operator {
             tag: "HashJoin".to_string(),
             data: vec![
                 lit_expr(string("inner")),
@@ -294,10 +285,12 @@ mod tests {
                 Arc::new(Expr::CoreExpr(CoreData::Literal(string("IndexScan")))),
                 Arc::new(Expr::CoreExpr(CoreData::Literal(string("FullScan")))),
             ],
-        }));
+        });
 
         // Create the expression to evaluate
-        let physical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Physical(op)));
+        let physical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Physical(
+            Materializable::Materialized(phys_op),
+        )));
 
         // Evaluate the expression
         let results = evaluate_and_collect(physical_op_expr, engine, harness).await;
@@ -305,46 +298,41 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Physical(op) => {
-                match &op.operator {
-                    Materializable::Materialized(op) => {
-                        // Check tag
-                        assert_eq!(op.tag, "HashJoin");
+            CoreData::Physical(Materializable::Materialized(phys_op)) => {
+                // Check tag
+                assert_eq!(phys_op.operator.tag, "HashJoin");
 
-                        // Check data - should have "inner" and 60
-                        assert_eq!(op.data.len(), 2);
-                        match &op.data[0].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("inner".to_string()));
-                            }
-                            _ => panic!("Expected string literal"),
-                        }
-                        match &op.data[1].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::Int64(60));
-                            }
-                            _ => panic!("Expected integer literal"),
-                        }
-
-                        // Check children - should have "IndexScan" and "FullScan"
-                        assert_eq!(op.children.len(), 2);
-                        match &op.children[0].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("IndexScan".to_string()));
-                            }
-                            _ => panic!("Expected string literal"),
-                        }
-                        match &op.children[1].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("FullScan".to_string()));
-                            }
-                            _ => panic!("Expected string literal"),
-                        }
+                // Check data - should have "inner" and 60
+                assert_eq!(phys_op.operator.data.len(), 2);
+                match &phys_op.operator.data[0].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("inner".to_string()));
                     }
-                    _ => panic!("Expected materialized physical operator"),
+                    _ => panic!("Expected string literal"),
+                }
+                match &phys_op.operator.data[1].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::Int64(60));
+                    }
+                    _ => panic!("Expected integer literal"),
+                }
+
+                // Check children - should have "IndexScan" and "FullScan"
+                assert_eq!(phys_op.operator.children.len(), 2);
+                match &phys_op.operator.children[0].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("IndexScan".to_string()));
+                    }
+                    _ => panic!("Expected string literal"),
+                }
+                match &phys_op.operator.children[1].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("FullScan".to_string()));
+                    }
+                    _ => panic!("Expected string literal"),
                 }
             }
-            _ => panic!("Expected physical operator"),
+            _ => panic!("Expected materialized physical operator"),
         }
     }
 
@@ -362,10 +350,11 @@ mod tests {
                 "sorted".to_string(),
             )))),
         };
-        let op = PhysicalOp::physical(Materializable::UnMaterialized(goal.clone()));
 
         // Create the expression to evaluate
-        let physical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Physical(op)));
+        let physical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Physical(
+            Materializable::UnMaterialized(goal.clone()),
+        )));
 
         // Evaluate the expression
         let results = evaluate_and_collect(physical_op_expr, engine, harness).await;
@@ -373,24 +362,19 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Physical(op) => {
-                match &op.operator {
-                    Materializable::UnMaterialized(result_goal) => {
-                        // Check that the goal is preserved
-                        assert_eq!(result_goal.group_id, goal.group_id);
+            CoreData::Physical(Materializable::UnMaterialized(result_goal)) => {
+                // Check that the goal is preserved
+                assert_eq!(result_goal.group_id, goal.group_id);
 
-                        // Check properties
-                        match &result_goal.properties.0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("sorted".to_string()));
-                            }
-                            _ => panic!("Expected string literal in goal properties"),
-                        }
+                // Check properties
+                match &result_goal.properties.0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("sorted".to_string()));
                     }
-                    _ => panic!("Expected unmaterialized physical operator"),
+                    _ => panic!("Expected string literal in goal properties"),
                 }
             }
-            _ => panic!("Expected physical operator"),
+            _ => panic!("Expected unmaterialized physical operator"),
         }
     }
 
@@ -414,14 +398,16 @@ mod tests {
             vec![],
         )));
 
-        let op = LogicalOp::logical(Materializable::Materialized(Operator {
+        let log_op = LogicalOp::logical(Operator {
             tag: "Join".to_string(),
             data: vec![lit_expr(string("inner"))],
             children: vec![scan1, scan2],
-        }));
+        });
 
         // Create the expression to evaluate
-        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(op)));
+        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(
+            Materializable::Materialized(log_op),
+        )));
 
         // Evaluate the expression
         let results = evaluate_and_collect(logical_op_expr, engine, harness).await;
@@ -429,67 +415,53 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Logical(op) => {
-                match &op.operator {
-                    Materializable::Materialized(op) => {
-                        // Check tag
-                        assert_eq!(op.tag, "Join");
+            CoreData::Logical(Materializable::Materialized(log_op)) => {
+                // Check tag
+                assert_eq!(log_op.operator.tag, "Join");
 
-                        // Check data
-                        assert_eq!(op.data.len(), 1);
-                        match &op.data[0].0 {
+                // Check data
+                assert_eq!(log_op.operator.data.len(), 1);
+                match &log_op.operator.data[0].0 {
+                    CoreData::Literal(lit) => {
+                        assert_eq!(lit, &Literal::String("inner".to_string()));
+                    }
+                    _ => panic!("Expected string literal"),
+                }
+
+                // Check children - should be two logical operators
+                assert_eq!(log_op.operator.children.len(), 2);
+
+                // Check first child
+                match &log_op.operator.children[0].0 {
+                    CoreData::Logical(Materializable::Materialized(child_log_op)) => {
+                        assert_eq!(child_log_op.operator.tag, "Scan");
+                        assert_eq!(child_log_op.operator.data.len(), 1);
+                        match &child_log_op.operator.data[0].0 {
                             CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("inner".to_string()));
+                                assert_eq!(lit, &Literal::String("orders".to_string()));
                             }
                             _ => panic!("Expected string literal"),
                         }
+                    }
+                    _ => panic!("Expected materialized logical operator as child"),
+                }
 
-                        // Check children - should be two logical operators
-                        assert_eq!(op.children.len(), 2);
-
-                        // Check first child
-                        match &op.children[0].0 {
-                            CoreData::Logical(child_op) => match &child_op.operator {
-                                Materializable::Materialized(child_op) => {
-                                    assert_eq!(child_op.tag, "Scan");
-                                    assert_eq!(child_op.data.len(), 1);
-                                    match &child_op.data[0].0 {
-                                        CoreData::Literal(lit) => {
-                                            assert_eq!(lit, &Literal::String("orders".to_string()));
-                                        }
-                                        _ => panic!("Expected string literal"),
-                                    }
-                                }
-                                _ => panic!("Expected materialized operator"),
-                            },
-                            _ => panic!("Expected logical operator as child"),
-                        }
-
-                        // Check second child
-                        match &op.children[1].0 {
-                            CoreData::Logical(child_op) => match &child_op.operator {
-                                Materializable::Materialized(child_op) => {
-                                    assert_eq!(child_op.tag, "Scan");
-                                    assert_eq!(child_op.data.len(), 1);
-                                    match &child_op.data[0].0 {
-                                        CoreData::Literal(lit) => {
-                                            assert_eq!(
-                                                lit,
-                                                &Literal::String("lineitem".to_string())
-                                            );
-                                        }
-                                        _ => panic!("Expected string literal"),
-                                    }
-                                }
-                                _ => panic!("Expected materialized operator"),
-                            },
-                            _ => panic!("Expected logical operator as child"),
+                // Check second child
+                match &log_op.operator.children[1].0 {
+                    CoreData::Logical(Materializable::Materialized(child_log_op)) => {
+                        assert_eq!(child_log_op.operator.tag, "Scan");
+                        assert_eq!(child_log_op.operator.data.len(), 1);
+                        match &child_log_op.operator.data[0].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("lineitem".to_string()));
+                            }
+                            _ => panic!("Expected string literal"),
                         }
                     }
-                    _ => panic!("Expected materialized logical operator"),
+                    _ => panic!("Expected materialized logical operator as child"),
                 }
             }
-            _ => panic!("Expected logical operator"),
+            _ => panic!("Expected materialized logical operator"),
         }
     }
 }

--- a/optd-dsl/src/engine/eval/operator.rs
+++ b/optd-dsl/src/engine/eval/operator.rs
@@ -23,10 +23,13 @@ pub(crate) async fn evaluate_logical_operator<O>(
 where
     O: Send + 'static,
 {
-    match op.0 {
+    match op.operator {
         // For unmaterialized operators, directly call the continuation with the unmaterialized
         // value.
-        UnMaterialized(group_id) => k(Value(Logical(LogicalOp(UnMaterialized(group_id))))).await,
+        UnMaterialized(group_id) => {
+            let result = Value(Logical(LogicalOp::logical(UnMaterialized(group_id))));
+            k(result).await
+        }
         // For materialized operators, evaluate all parts and construct the result.
         Materialized(op) => {
             evaluate_operator(
@@ -36,8 +39,9 @@ where
                 engine,
                 Arc::new(move |constructed_op| {
                     Box::pin(capture!([k], async move {
-                        // Wrap the constructed operator in the logical operator structure.
-                        let result = Value(Logical(LogicalOp(Materialized(constructed_op))));
+                        // Wrap the constructed operator in the logical operator structure
+                        let result =
+                            Value(Logical(LogicalOp::logical(Materialized(constructed_op))));
                         k(result).await
                     }))
                 }),
@@ -62,10 +66,13 @@ pub(crate) async fn evaluate_physical_operator<O>(
 where
     O: Send + 'static,
 {
-    match op.0 {
+    match op.operator {
         // For unmaterialized operators, continue with the unmaterialized value.
         UnMaterialized(physical_goal) => {
-            k(Value(Physical(PhysicalOp(UnMaterialized(physical_goal))))).await
+            let result = Value(Physical(PhysicalOp::physical(UnMaterialized(
+                physical_goal,
+            ))));
+            k(result).await
         }
         // For materialized operators, evaluate all parts and construct the result.
         Materialized(op) => {
@@ -76,7 +83,9 @@ where
                 engine,
                 Arc::new(move |constructed_op| {
                     Box::pin(capture!([k], async move {
-                        k(Value(Physical(PhysicalOp(Materialized(constructed_op))))).await
+                        let result =
+                            Value(Physical(PhysicalOp::physical(Materialized(constructed_op))));
+                        k(result).await
                     }))
                 }),
             )
@@ -162,7 +171,7 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a materialized logical operator expression with nested expressions to evaluate
-        let op = LogicalOp(Materializable::Materialized(Operator {
+        let op = LogicalOp::logical(Materializable::Materialized(Operator {
             tag: "Join".to_string(),
             data: vec![
                 lit_expr(string("inner")),
@@ -187,41 +196,46 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Logical(LogicalOp(Materializable::Materialized(op))) => {
-                // Check tag
-                assert_eq!(op.tag, "Join");
+            CoreData::Logical(op) => {
+                match &op.operator {
+                    Materializable::Materialized(op) => {
+                        // Check tag
+                        assert_eq!(op.tag, "Join");
 
-                // Check data - should have "inner" and 15
-                assert_eq!(op.data.len(), 2);
-                match &op.data[0].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("inner".to_string()));
-                    }
-                    _ => panic!("Expected string literal"),
-                }
-                match &op.data[1].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::Int64(15));
-                    }
-                    _ => panic!("Expected integer literal"),
-                }
+                        // Check data - should have "inner" and 15
+                        assert_eq!(op.data.len(), 2);
+                        match &op.data[0].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("inner".to_string()));
+                            }
+                            _ => panic!("Expected string literal"),
+                        }
+                        match &op.data[1].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::Int64(15));
+                            }
+                            _ => panic!("Expected integer literal"),
+                        }
 
-                // Check children - should have "orders" and "lineitem"
-                assert_eq!(op.children.len(), 2);
-                match &op.children[0].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("orders".to_string()));
+                        // Check children - should have "orders" and "lineitem"
+                        assert_eq!(op.children.len(), 2);
+                        match &op.children[0].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("orders".to_string()));
+                            }
+                            _ => panic!("Expected string literal"),
+                        }
+                        match &op.children[1].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("lineitem".to_string()));
+                            }
+                            _ => panic!("Expected string literal"),
+                        }
                     }
-                    _ => panic!("Expected string literal"),
-                }
-                match &op.children[1].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("lineitem".to_string()));
-                    }
-                    _ => panic!("Expected string literal"),
+                    _ => panic!("Expected materialized logical operator"),
                 }
             }
-            _ => panic!("Expected materialized logical operator"),
+            _ => panic!("Expected logical operator"),
         }
     }
 
@@ -234,7 +248,7 @@ mod tests {
 
         // Create an unmaterialized logical operator with a group ID
         let group_id = GroupId(42);
-        let op = LogicalOp(Materializable::UnMaterialized(group_id));
+        let op = LogicalOp::logical(Materializable::UnMaterialized(group_id));
 
         // Create the expression to evaluate
         let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(op)));
@@ -245,11 +259,16 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Logical(LogicalOp(Materializable::UnMaterialized(id))) => {
-                // Check that the group ID is preserved
-                assert_eq!(*id, group_id);
+            CoreData::Logical(op) => {
+                match &op.operator {
+                    Materializable::UnMaterialized(id) => {
+                        // Check that the group ID is preserved
+                        assert_eq!(*id, group_id);
+                    }
+                    _ => panic!("Expected unmaterialized logical operator"),
+                }
             }
-            _ => panic!("Expected unmaterialized logical operator"),
+            _ => panic!("Expected logical operator"),
         }
     }
 
@@ -261,7 +280,7 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a materialized physical operator expression with nested expressions to evaluate
-        let op = PhysicalOp(Materializable::Materialized(Operator {
+        let op = PhysicalOp::physical(Materializable::Materialized(Operator {
             tag: "HashJoin".to_string(),
             data: vec![
                 lit_expr(string("inner")),
@@ -286,41 +305,46 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Physical(PhysicalOp(Materializable::Materialized(op))) => {
-                // Check tag
-                assert_eq!(op.tag, "HashJoin");
+            CoreData::Physical(op) => {
+                match &op.operator {
+                    Materializable::Materialized(op) => {
+                        // Check tag
+                        assert_eq!(op.tag, "HashJoin");
 
-                // Check data - should have "inner" and 60
-                assert_eq!(op.data.len(), 2);
-                match &op.data[0].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("inner".to_string()));
-                    }
-                    _ => panic!("Expected string literal"),
-                }
-                match &op.data[1].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::Int64(60));
-                    }
-                    _ => panic!("Expected integer literal"),
-                }
+                        // Check data - should have "inner" and 60
+                        assert_eq!(op.data.len(), 2);
+                        match &op.data[0].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("inner".to_string()));
+                            }
+                            _ => panic!("Expected string literal"),
+                        }
+                        match &op.data[1].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::Int64(60));
+                            }
+                            _ => panic!("Expected integer literal"),
+                        }
 
-                // Check children - should have "IndexScan" and "FullScan"
-                assert_eq!(op.children.len(), 2);
-                match &op.children[0].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("IndexScan".to_string()));
+                        // Check children - should have "IndexScan" and "FullScan"
+                        assert_eq!(op.children.len(), 2);
+                        match &op.children[0].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("IndexScan".to_string()));
+                            }
+                            _ => panic!("Expected string literal"),
+                        }
+                        match &op.children[1].0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("FullScan".to_string()));
+                            }
+                            _ => panic!("Expected string literal"),
+                        }
                     }
-                    _ => panic!("Expected string literal"),
-                }
-                match &op.children[1].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("FullScan".to_string()));
-                    }
-                    _ => panic!("Expected string literal"),
+                    _ => panic!("Expected materialized physical operator"),
                 }
             }
-            _ => panic!("Expected materialized physical operator"),
+            _ => panic!("Expected physical operator"),
         }
     }
 
@@ -338,7 +362,7 @@ mod tests {
                 "sorted".to_string(),
             )))),
         };
-        let op = PhysicalOp(Materializable::UnMaterialized(goal.clone()));
+        let op = PhysicalOp::physical(Materializable::UnMaterialized(goal.clone()));
 
         // Create the expression to evaluate
         let physical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Physical(op)));
@@ -349,19 +373,24 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Physical(PhysicalOp(Materializable::UnMaterialized(result_goal))) => {
-                // Check that the goal is preserved
-                assert_eq!(result_goal.group_id, goal.group_id);
+            CoreData::Physical(op) => {
+                match &op.operator {
+                    Materializable::UnMaterialized(result_goal) => {
+                        // Check that the goal is preserved
+                        assert_eq!(result_goal.group_id, goal.group_id);
 
-                // Check properties
-                match &result_goal.properties.0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("sorted".to_string()));
+                        // Check properties
+                        match &result_goal.properties.0 {
+                            CoreData::Literal(lit) => {
+                                assert_eq!(lit, &Literal::String("sorted".to_string()));
+                            }
+                            _ => panic!("Expected string literal in goal properties"),
+                        }
                     }
-                    _ => panic!("Expected string literal in goal properties"),
+                    _ => panic!("Expected unmaterialized physical operator"),
                 }
             }
-            _ => panic!("Expected unmaterialized physical operator"),
+            _ => panic!("Expected physical operator"),
         }
     }
 
@@ -385,7 +414,7 @@ mod tests {
             vec![],
         )));
 
-        let op = LogicalOp(Materializable::Materialized(Operator {
+        let op = LogicalOp::logical(Materializable::Materialized(Operator {
             tag: "Join".to_string(),
             data: vec![lit_expr(string("inner"))],
             children: vec![scan1, scan2],
@@ -400,53 +429,67 @@ mod tests {
         // Check result
         assert_eq!(results.len(), 1);
         match &results[0].0 {
-            CoreData::Logical(LogicalOp(Materializable::Materialized(op))) => {
-                // Check tag
-                assert_eq!(op.tag, "Join");
+            CoreData::Logical(op) => {
+                match &op.operator {
+                    Materializable::Materialized(op) => {
+                        // Check tag
+                        assert_eq!(op.tag, "Join");
 
-                // Check data
-                assert_eq!(op.data.len(), 1);
-                match &op.data[0].0 {
-                    CoreData::Literal(lit) => {
-                        assert_eq!(lit, &Literal::String("inner".to_string()));
-                    }
-                    _ => panic!("Expected string literal"),
-                }
-
-                // Check children - should be two logical operators
-                assert_eq!(op.children.len(), 2);
-
-                // Check first child
-                match &op.children[0].0 {
-                    CoreData::Logical(LogicalOp(Materializable::Materialized(child_op))) => {
-                        assert_eq!(child_op.tag, "Scan");
-                        assert_eq!(child_op.data.len(), 1);
-                        match &child_op.data[0].0 {
+                        // Check data
+                        assert_eq!(op.data.len(), 1);
+                        match &op.data[0].0 {
                             CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("orders".to_string()));
+                                assert_eq!(lit, &Literal::String("inner".to_string()));
                             }
                             _ => panic!("Expected string literal"),
                         }
-                    }
-                    _ => panic!("Expected logical operator as child"),
-                }
 
-                // Check second child
-                match &op.children[1].0 {
-                    CoreData::Logical(LogicalOp(Materializable::Materialized(child_op))) => {
-                        assert_eq!(child_op.tag, "Scan");
-                        assert_eq!(child_op.data.len(), 1);
-                        match &child_op.data[0].0 {
-                            CoreData::Literal(lit) => {
-                                assert_eq!(lit, &Literal::String("lineitem".to_string()));
-                            }
-                            _ => panic!("Expected string literal"),
+                        // Check children - should be two logical operators
+                        assert_eq!(op.children.len(), 2);
+
+                        // Check first child
+                        match &op.children[0].0 {
+                            CoreData::Logical(child_op) => match &child_op.operator {
+                                Materializable::Materialized(child_op) => {
+                                    assert_eq!(child_op.tag, "Scan");
+                                    assert_eq!(child_op.data.len(), 1);
+                                    match &child_op.data[0].0 {
+                                        CoreData::Literal(lit) => {
+                                            assert_eq!(lit, &Literal::String("orders".to_string()));
+                                        }
+                                        _ => panic!("Expected string literal"),
+                                    }
+                                }
+                                _ => panic!("Expected materialized operator"),
+                            },
+                            _ => panic!("Expected logical operator as child"),
+                        }
+
+                        // Check second child
+                        match &op.children[1].0 {
+                            CoreData::Logical(child_op) => match &child_op.operator {
+                                Materializable::Materialized(child_op) => {
+                                    assert_eq!(child_op.tag, "Scan");
+                                    assert_eq!(child_op.data.len(), 1);
+                                    match &child_op.data[0].0 {
+                                        CoreData::Literal(lit) => {
+                                            assert_eq!(
+                                                lit,
+                                                &Literal::String("lineitem".to_string())
+                                            );
+                                        }
+                                        _ => panic!("Expected string literal"),
+                                    }
+                                }
+                                _ => panic!("Expected materialized operator"),
+                            },
+                            _ => panic!("Expected logical operator as child"),
                         }
                     }
-                    _ => panic!("Expected logical operator as child"),
+                    _ => panic!("Expected materialized logical operator"),
                 }
             }
-            _ => panic!("Expected materialized logical operator"),
+            _ => panic!("Expected logical operator"),
         }
     }
 }

--- a/optd-dsl/src/engine/test_utils.rs
+++ b/optd-dsl/src/engine/test_utils.rs
@@ -174,7 +174,7 @@ pub fn create_logical_operator(tag: &str, data: Vec<Value>, children: Vec<Value>
         children,
     };
 
-    Value(CoreData::Logical(LogicalOp::logical(Materialized(op))))
+    Value(CoreData::Logical(Materialized(LogicalOp::logical(op))))
 }
 
 /// Helper to create a simple physical operator value.
@@ -185,7 +185,7 @@ pub fn create_physical_operator(tag: &str, data: Vec<Value>, children: Vec<Value
         children,
     };
 
-    Value(CoreData::Physical(PhysicalOp::physical(Materialized(op))))
+    Value(CoreData::Physical(Materialized(PhysicalOp::physical(op))))
 }
 
 /// Runs a test by evaluating the expression and collecting all results with a custom continuation.

--- a/optd-dsl/src/engine/test_utils.rs
+++ b/optd-dsl/src/engine/test_utils.rs
@@ -1,12 +1,12 @@
+use super::{Continuation, EngineResponse};
 use crate::analyzer::hir::{
     CoreData, Expr, Goal, GroupId, Literal, LogicalOp, MatchArm, Materializable, Operator, Pattern,
     PhysicalOp, Value,
 };
 use crate::engine::Engine;
+use Materializable::*;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
-
-use super::{Continuation, EngineResponse};
 
 /// A test harness for the evaluation engine.
 #[derive(Clone)]
@@ -174,9 +174,7 @@ pub fn create_logical_operator(tag: &str, data: Vec<Value>, children: Vec<Value>
         children,
     };
 
-    Value(CoreData::Logical(LogicalOp(Materializable::Materialized(
-        op,
-    ))))
+    Value(CoreData::Logical(LogicalOp::logical(Materialized(op))))
 }
 
 /// Helper to create a simple physical operator value.
@@ -187,9 +185,7 @@ pub fn create_physical_operator(tag: &str, data: Vec<Value>, children: Vec<Value
         children,
     };
 
-    Value(CoreData::Physical(PhysicalOp(
-        Materializable::Materialized(op),
-    )))
+    Value(CoreData::Physical(PhysicalOp::physical(Materialized(op))))
 }
 
 /// Runs a test by evaluating the expression and collecting all results with a custom continuation.

--- a/optd-dsl/src/lexer/lex.rs
+++ b/optd-dsl/src/lexer/lex.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
-
+use super::{error::LexerError, tokens::Token};
+use crate::utils::{error::CompileError, span::Span};
 use chumsky::{
     Parser, Stream,
     error::Simple,
@@ -7,10 +7,7 @@ use chumsky::{
     text::{TextParser, digits, ident, int},
 };
 use ordered_float::OrderedFloat;
-
-use crate::utils::{error::CompileError, span::Span};
-
-use super::{error::LexerError, tokens::Token};
+use std::collections::HashMap;
 
 /// Lexes a source string into a sequence of tokens with their positions.
 /// Uses Chumsky for lexing and Ariadne for error reporting.
@@ -142,6 +139,7 @@ fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char, Span>> 
         just(",").to(Token::Comma),
         just(".").to(Token::Dot),
         just(":").to(Token::Colon),
+        just("?").to(Token::Question),
     ));
 
     let comments = just("//")

--- a/optd-dsl/src/lexer/tokens.rs
+++ b/optd-dsl/src/lexer/tokens.rs
@@ -19,6 +19,7 @@ pub enum Token {
     Then,
     Else,
     Fail,
+    None,
 
     // Literals
     TermIdent(String),
@@ -62,6 +63,7 @@ pub enum Token {
     Dot,        // .
     Colon,      // :
     UnderScore, // _
+    Question,   // ?
 }
 
 pub const ALL_DELIMITERS: [(Token, Token); 3] = [
@@ -90,6 +92,7 @@ impl std::fmt::Display for Token {
             Token::Then => write!(f, "then"),
             Token::Else => write!(f, "else"),
             Token::Fail => write!(f, "fail"),
+            Token::None => write!(f, "None"),
 
             // Literals
             Token::TermIdent(ident) => write!(f, "{}", ident),
@@ -133,6 +136,7 @@ impl std::fmt::Display for Token {
             Token::Dot => write!(f, "."),
             Token::Colon => write!(f, ":"),
             Token::UnderScore => write!(f, "_"),
+            Token::Question => write!(f, "?"),
         }
     }
 }

--- a/optd-dsl/src/parser/ast.rs
+++ b/optd-dsl/src/parser/ast.rs
@@ -35,8 +35,8 @@ pub enum Type {
     Tuple(Vec<Spanned<Type>>),
     /// Map/dictionary with key and value types
     Map(Spanned<Type>, Spanned<Type>),
-   /// Optional type (represents a value that might be absent)
-   Optional(Spanned<Type>),
+    /// Optional type (represents a value that might be absent)
+    Optional(Spanned<Type>),
 
     // User defined types
     /// Algebraic Data Type reference by name

--- a/optd-dsl/src/parser/ast.rs
+++ b/optd-dsl/src/parser/ast.rs
@@ -35,6 +35,8 @@ pub enum Type {
     Tuple(Vec<Spanned<Type>>),
     /// Map/dictionary with key and value types
     Map(Spanned<Type>, Spanned<Type>),
+   /// Optional type (represents a value that might be absent)
+   Optional(Spanned<Type>),
 
     // User defined types
     /// Algebraic Data Type reference by name

--- a/optd-dsl/src/parser/type.rs
+++ b/optd-dsl/src/parser/type.rs
@@ -12,6 +12,31 @@ use crate::{
 
 use super::{ast::Type, utils::delimited_parser};
 
+/// Creates a parser for type expressions.
+///
+/// This parser supports:
+/// - Primitive types: I64, String, Bool, Float64, Unit
+/// - Array types: \[T\]
+/// - Tuple types: (T1, T2, ...)
+/// - Map types: {K : V}
+/// - Function types: T1 -> T2
+/// - User-defined types: TypeName
+/// - Optional types: T?
+///
+/// Syntax examples:
+/// - I64                   - Integer type
+/// - String                - String type
+/// - \[I64\]                 - Array of integers
+/// - {String : I64}        - Map from strings to integers
+/// - (I64, String)         - Tuple with integer and string
+/// - I64 -> String         - Function from integer to string
+/// - I64?                  - Optional integer
+/// - \[String\]?             - Optional array of strings
+/// - I64 -> String?        - Function returning optional string
+/// - (I64 -> String)?      - Optional function
+///
+/// The parser follows standard precedence rules and supports
+/// arbitrary nesting of type expressions.
 pub fn type_parser() -> impl Parser<Token, Spanned<Type>, Error = Simple<Token, Span>> + Clone {
     recursive(|type_parser| {
         let atom = {
@@ -83,7 +108,8 @@ pub fn type_parser() -> impl Parser<Token, Spanned<Type>, Error = Simple<Token, 
             ))
         };
 
-        atom.clone()
+        // Process function types
+        let function_type = atom
             .then(
                 just(Token::SmallArrow)
                     .ignore_then(type_parser)
@@ -95,6 +121,22 @@ pub fn type_parser() -> impl Parser<Token, Spanned<Type>, Error = Simple<Token, 
                     Spanned::new(Type::Closure(param_type, return_type), span)
                 }
                 None => param_type,
+            });
+
+        // Process optional types
+        function_type
+            .then(
+                just(Token::Question)
+                    .repeated()
+                    .at_least(0)
+                    .collect::<Vec<_>>(),
+            )
+            .map_with_span(|(base_type, question_marks), span| {
+                let mut result = base_type;
+                for _ in question_marks {
+                    result = Spanned::new(Type::Optional(result), span.clone());
+                }
+                result
             })
     })
 }
@@ -212,6 +254,63 @@ mod tests {
     }
 
     #[test]
+    fn test_optional_types() {
+        // Basic optional types
+        let result = parse_type("I64?").unwrap();
+        assert!(matches!(*result.value,
+            Type::Optional(inner) if matches!(*inner.value, Type::Int64)
+        ));
+
+        let result = parse_type("String?").unwrap();
+        assert!(matches!(*result.value,
+            Type::Optional(inner) if matches!(*inner.value, Type::String)
+        ));
+
+        // Nested optional types
+        let result = parse_type("I64??").unwrap();
+        assert!(matches!(*result.value,
+            Type::Optional(inner) if matches!(*inner.clone().value,
+                Type::Optional(inner_inner) if matches!(*inner_inner.value, Type::Int64)
+            )
+        ));
+
+        // Complex types with optional
+        let result = parse_type("[I64]?").unwrap();
+        assert!(matches!(*result.value,
+            Type::Optional(inner) if matches!(*inner.clone().value,
+                Type::Array(arr_inner) if matches!(*arr_inner.value, Type::Int64)
+            )
+        ));
+
+        let result = parse_type("(I64, String)?").unwrap();
+        assert!(matches!(*result.value,
+            Type::Optional(inner) if matches!(*inner.value, Type::Tuple(_))
+        ));
+
+        // Function return type is optional
+        let result = parse_type("I64 -> String?").unwrap();
+        assert!(matches!(*result.value,
+            Type::Closure(param, ret)
+            if matches!(*param.value, Type::Int64)
+            && matches!(*ret.value, Type::Optional(_))
+            && matches!(*ret.value.clone(),
+                Type::Optional(inner) if matches!(*inner.value, Type::String))
+        ));
+
+        // Entire function type is optional
+        let result = parse_type("(I64 -> String)?").unwrap();
+        assert!(matches!(*result.value,
+            Type::Optional(inner) if matches!(*inner.value, Type::Closure(_, _))
+        ));
+
+        // Optional map type
+        let result = parse_type("{String : I64}?").unwrap();
+        assert!(matches!(*result.value,
+            Type::Optional(inner) if matches!(*inner.value, Type::Map(_, _))
+        ));
+    }
+
+    #[test]
     fn test_complex_type() {
         // Test mix of Map, Array, Tuple, and Closure
         let insane_type = "{String : [((I64, [{String : Physical}]) -> [(AdtType, LogicalProps, (Bool -> [Scalar]))])]}";
@@ -261,10 +360,9 @@ mod tests {
             }
         }
 
-        // Test an even more complex nested type
-        let even_more_insane =
-            "{String : {I64 : [(Logical -> {String : [((Bool, [Scalar]) -> Physical)]})]}}";
-        assert!(parse_type(even_more_insane).is_ok());
-        assert!(parse_type(even_more_insane).is_ok());
+        // Test an even more insane nested type with optionals
+        let optional_insane =
+            "{String? : {I64 : [(Logical -> {String : [((Bool?, [Scalar]?) -> Physical?)]?}?)]}}?";
+        assert!(parse_type(optional_insane).is_ok());
     }
 }


### PR DESCRIPTION
This PR does two things:

1. Add optional types in the DSL to be able to return `None` when the rule application fails for example. 

Adapted the parser accordingly, as well as the HIR. See syntax below for types now.

```
/// Syntax examples:
/// - I64                   - Integer type
/// - String                - String type
/// - [I64]                 - Array of integers
/// - {String : I64}        - Map from strings to integers
/// - (I64, String)         - Tuple with integer and string
/// - I64 -> String         - Function from integer to string
/// - I64?                  - Optional integer
/// - [String]?             - Optional array of strings
/// - I64 -> String?        - Function returning optional string
/// - (I64 -> String)?      - Optional function
```

2. We need a type hierarchy in the DSL for Logical & Physical operators. At some places, we want to be able to access 

Specifically, we define:

```
StoredLogical: Operator + GroupId
Logical: Operator

StoredLogical <: Logical
```

and,

```
CostedPhysical: Operator + Goal (i.e. GroupId + Props) + Cost (i.e. f64 + stats in the future)
StoredPhysical: Operator + Goal
Physical: Operator

CostedPhysical <: StoredPhysical <: Physical
```

This translates as follows in the HIR.

```
pub struct LogicalOp<T> {
    pub operator: Materializable<Operator<T>, GroupId>,
    pub group_id: Option<GroupId>,
}
pub struct PhysicalOp<T> {
    pub operator: Materializable<Operator<T>, Goal>,
    pub goal: Option<Goal>,
    pub cost: Option<Box<Value>>,
}
```