### PR TITLE
(feat) Analyzer HIR Metadata Setup

### DIFF
--- a/optd-dsl/src/analyzer/hir.rs
+++ b/optd-dsl/src/analyzer/hir.rs
@@ -15,9 +15,11 @@
 //! unified representation that can be transformed into optimizer-specific
 //! intermediate representations through the bridge modules.
 
-use std::{collections::HashMap, sync::Arc};
-
 use super::context::Context;
+use super::r#type::Type;
+use crate::utils::span::Span;
+use std::fmt::Debug;
+use std::{collections::HashMap, sync::Arc};
 
 /// Unique identifier for variables, functions, types, etc.
 pub type Identifier = String;
@@ -190,25 +192,68 @@ pub enum CoreData<T> {
     None,
 }
 
-/// Expression nodes in the HIR
+/// Metadata that can be attached to expression nodes
+///
+/// This trait allows for different types of metadata to be attached to
+/// expression nodes while maintaining a common interface for access.
+pub trait ExprMetadata: Debug + Clone {}
+
+/// Empty metadata implementation for cases where no additional data is needed
+#[derive(Debug, Clone, Default)]
+pub struct NoMetadata;
+impl ExprMetadata for NoMetadata {}
+
+/// Combined span and type information for an expression
 #[derive(Debug, Clone)]
-pub enum Expr {
+pub struct TypedSpan {
+    /// Source code location.
+    pub span: Span,
+    /// Inferred type.
+    pub ty: Type,
+}
+impl ExprMetadata for TypedSpan {}
+
+/// Expression nodes in the HIR with optional metadata
+///
+/// The M type parameter allows attaching different kinds of metadata to expressions,
+/// such as type information, source spans, or both.
+#[derive(Debug, Clone)]
+pub struct Expr<M: ExprMetadata = NoMetadata> {
+    /// The actual expression node
+    pub kind: ExprKind<M>,
+    /// Optional metadata for the expression
+    pub metadata: M,
+}
+
+impl Expr<NoMetadata> {
+    /// Creates a new expression without metadata
+    pub fn new(kind: ExprKind<NoMetadata>) -> Self {
+        Self {
+            kind,
+            metadata: NoMetadata,
+        }
+    }
+}
+
+/// Expression node kinds without metadata
+#[derive(Debug, Clone)]
+pub enum ExprKind<M: ExprMetadata = NoMetadata> {
     /// Pattern matching expression
-    PatternMatch(Arc<Expr>, Vec<MatchArm>),
+    PatternMatch(Arc<Expr<M>>, Vec<MatchArm<M>>),
     /// Conditional expression
-    IfThenElse(Arc<Expr>, Arc<Expr>, Arc<Expr>),
+    IfThenElse(Arc<Expr<M>>, Arc<Expr<M>>, Arc<Expr<M>>),
     /// Variable binding
-    Let(Identifier, Arc<Expr>, Arc<Expr>),
+    Let(Identifier, Arc<Expr<M>>, Arc<Expr<M>>),
     /// Binary operation
-    Binary(Arc<Expr>, BinOp, Arc<Expr>),
+    Binary(Arc<Expr<M>>, BinOp, Arc<Expr<M>>),
     /// Unary operation
-    Unary(UnaryOp, Arc<Expr>),
+    Unary(UnaryOp, Arc<Expr<M>>),
     /// Function call
-    Call(Arc<Expr>, Vec<Arc<Expr>>),
+    Call(Arc<Expr<M>>, Vec<Arc<Expr<M>>>),
     /// Variable reference
     Ref(Identifier),
     /// Core expression
-    CoreExpr(CoreData<Arc<Expr>>),
+    CoreExpr(CoreData<Arc<Expr<M>>>),
     /// Core value
     CoreVal(Value),
 }
@@ -238,11 +283,11 @@ pub enum Pattern {
 
 /// Match arm combining pattern and expression
 #[derive(Debug, Clone)]
-pub struct MatchArm {
+pub struct MatchArm<M: ExprMetadata = NoMetadata> {
     /// Pattern to match against
     pub pattern: Pattern,
     /// Expression to evaluate if pattern matches
-    pub expr: Arc<Expr>,
+    pub expr: Arc<Expr<M>>,
 }
 
 /// Standard binary operators
@@ -269,7 +314,11 @@ pub enum UnaryOp {
 
 /// Program representation after the analysis phase
 #[derive(Debug)]
-pub struct HIR {
+pub struct HIR<M: ExprMetadata = NoMetadata> {
     pub context: Context,
     pub annotations: HashMap<Identifier, Vec<Annotation>>,
+    pub expressions: Vec<Expr<M>>,
 }
+
+/// Type alias for HIR with both type and source location information
+pub type TypedSpannedHIR = HIR<TypedSpan>;

--- a/optd-dsl/src/analyzer/mod.rs
+++ b/optd-dsl/src/analyzer/mod.rs
@@ -1,4 +1,5 @@
 pub mod context;
 pub mod hir;
 pub mod semantic_checker;
+pub mod r#type;
 pub mod type_checker;

--- a/optd-dsl/src/analyzer/type.rs
+++ b/optd-dsl/src/analyzer/type.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{HashMap, HashSet},
     ops::{Deref, DerefMut},
 };
+
 pub type Identifier = String;
 
 /// Represents types in the language.

--- a/optd-dsl/src/analyzer/type_checker/mod.rs
+++ b/optd-dsl/src/analyzer/type_checker/mod.rs
@@ -1,2 +1,1 @@
 pub mod error;
-pub mod r#type;

--- a/optd-dsl/src/engine/eval/core.rs
+++ b/optd-dsl/src/engine/eval/core.rs
@@ -161,10 +161,11 @@ mod tests {
     use crate::{
         analyzer::{
             context::Context,
-            hir::{CoreData, Expr, FunKind, Literal, Value},
+            hir::{CoreData, Expr, ExprKind, FunKind, Literal, Value},
         },
         engine::Engine,
     };
+    use ExprKind::*;
     use std::sync::Arc;
 
     /// Test evaluation of literal values
@@ -175,7 +176,7 @@ mod tests {
         let harness = TestHarness::new();
 
         // Create a literal expression
-        let literal_expr = Arc::new(Expr::CoreExpr(CoreData::Literal(int(42))));
+        let literal_expr = Arc::new(Expr::new(CoreExpr(CoreData::Literal(int(42)))));
         let results = evaluate_and_collect(literal_expr, engine, harness).await;
 
         // Check result
@@ -196,11 +197,11 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create an array expression with values to evaluate
-        let array_expr = Arc::new(Expr::CoreExpr(CoreData::Array(vec![
+        let array_expr = Arc::new(Expr::new(CoreExpr(CoreData::Array(vec![
             lit_expr(int(1)),
             lit_expr(int(2)),
             lit_expr(int(3)),
-        ])));
+        ]))));
 
         let results = evaluate_and_collect(array_expr, engine, harness).await;
 
@@ -234,11 +235,11 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a tuple expression with mixed types
-        let tuple_expr = Arc::new(Expr::CoreExpr(CoreData::Tuple(vec![
+        let tuple_expr = Arc::new(Expr::new(CoreExpr(CoreData::Tuple(vec![
             lit_expr(int(42)),
             lit_expr(string("hello")),
             lit_expr(Literal::Bool(true)),
-        ])));
+        ]))));
 
         let results = evaluate_and_collect(tuple_expr, engine, harness).await;
 
@@ -272,10 +273,10 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a struct expression
-        let struct_expr = Arc::new(Expr::CoreExpr(CoreData::Struct(
+        let struct_expr = Arc::new(Expr::new(CoreExpr(CoreData::Struct(
             "Point".to_string(),
             vec![lit_expr(int(10)), lit_expr(int(20))],
-        )));
+        ))));
 
         let results = evaluate_and_collect(struct_expr, engine, harness).await;
 
@@ -306,11 +307,11 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a map expression
-        let map_expr = Arc::new(Expr::CoreExpr(CoreData::Map(vec![
+        let map_expr = Arc::new(Expr::new(CoreExpr(CoreData::Map(vec![
             (lit_expr(string("a")), lit_expr(int(1))),
             (lit_expr(string("b")), lit_expr(int(2))),
             (lit_expr(string("c")), lit_expr(int(3))),
-        ])));
+        ]))));
 
         let results = evaluate_and_collect(map_expr, engine, harness).await;
 
@@ -371,10 +372,10 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a function expression (just a simple closure)
-        let fn_expr = Arc::new(Expr::CoreExpr(CoreData::Function(FunKind::Closure(
+        let fn_expr = Arc::new(Expr::new(CoreExpr(CoreData::Function(FunKind::Closure(
             vec!["x".to_string()],
             lit_expr(int(42)), // Just returns 42 regardless of argument
-        ))));
+        )))));
 
         let results = evaluate_and_collect(fn_expr, engine, harness).await;
 
@@ -396,7 +397,7 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a null expression
-        let null_expr = Arc::new(Expr::CoreExpr(CoreData::None));
+        let null_expr = Arc::new(Expr::new(CoreExpr(CoreData::None)));
 
         let results = evaluate_and_collect(null_expr, engine, harness).await;
 
@@ -430,9 +431,9 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a fail expression with a message
-        let fail_expr = Arc::new(Expr::CoreExpr(CoreData::Fail(Box::new(Arc::new(
-            Expr::CoreVal(Value(CoreData::Literal(string("error message")))),
-        )))));
+        let fail_expr = Arc::new(Expr::new(CoreExpr(CoreData::Fail(Box::new(Arc::new(
+            Expr::new(CoreVal(Value(CoreData::Literal(string("error message"))))),
+        ))))));
 
         let results =
             evaluate_and_collect_with_custom_k(fail_expr, engine, harness, return_k).await;

--- a/optd-dsl/src/engine/eval/expr.rs
+++ b/optd-dsl/src/engine/eval/expr.rs
@@ -345,7 +345,7 @@ where
 mod tests {
     use crate::analyzer::{
         context::Context,
-        hir::{BinOp, CoreData, Expr, FunKind, Literal, Value},
+        hir::{BinOp, CoreData, Expr, ExprKind, FunKind, Literal, Value},
     };
     use crate::engine::{
         Engine,
@@ -354,6 +354,7 @@ mod tests {
             ref_expr, string,
         },
     };
+    use ExprKind::*;
     use std::sync::Arc;
 
     /// Test if-then-else expressions with true and false conditions
@@ -364,20 +365,20 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // if true then "yes" else "no"
-        let true_condition = Arc::new(Expr::IfThenElse(
+        let true_condition = Arc::new(Expr::new(IfThenElse(
             lit_expr(boolean(true)),
             lit_expr(string("yes")),
             lit_expr(string("no")),
-        ));
+        )));
         let true_results =
             evaluate_and_collect(true_condition, engine.clone(), harness.clone()).await;
 
         // if false then "yes" else "no"
-        let false_condition = Arc::new(Expr::IfThenElse(
+        let false_condition = Arc::new(Expr::new(IfThenElse(
             lit_expr(boolean(false)),
             lit_expr(string("yes")),
             lit_expr(string("no")),
-        ));
+        )));
         let false_results =
             evaluate_and_collect(false_condition, engine.clone(), harness.clone()).await;
 
@@ -386,11 +387,23 @@ mod tests {
         ctx.bind("x".to_string(), lit_val(int(20)));
         let engine_with_x = Engine::new(ctx);
 
-        let complex_condition = Arc::new(Expr::IfThenElse(
-            Arc::new(Expr::Binary(ref_expr("x"), BinOp::Lt, lit_expr(int(10)))),
-            Arc::new(Expr::Binary(ref_expr("x"), BinOp::Div, lit_expr(int(2)))),
-            Arc::new(Expr::Binary(ref_expr("x"), BinOp::Mul, lit_expr(int(2)))),
-        ));
+        let complex_condition = Arc::new(Expr::new(IfThenElse(
+            Arc::new(Expr::new(Binary(
+                ref_expr("x"),
+                BinOp::Lt,
+                lit_expr(int(10)),
+            ))),
+            Arc::new(Expr::new(Binary(
+                ref_expr("x"),
+                BinOp::Div,
+                lit_expr(int(2)),
+            ))),
+            Arc::new(Expr::new(Binary(
+                ref_expr("x"),
+                BinOp::Mul,
+                lit_expr(int(2)),
+            ))),
+        )));
 
         let complex_results = evaluate_and_collect(complex_condition, engine_with_x, harness).await;
 
@@ -425,11 +438,15 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // let x = 10 in x + 5
-        let let_expr = Arc::new(Expr::Let(
+        let let_expr = Arc::new(Expr::new(Let(
             "x".to_string(),
             lit_expr(int(10)),
-            Arc::new(Expr::Binary(ref_expr("x"), BinOp::Add, lit_expr(int(5)))),
-        ));
+            Arc::new(Expr::new(Binary(
+                ref_expr("x"),
+                BinOp::Add,
+                lit_expr(int(5)),
+            ))),
+        )));
 
         let results = evaluate_and_collect(let_expr, engine, harness).await;
 
@@ -452,15 +469,19 @@ mod tests {
         // let x = 10 in
         //   let y = x * 2 in
         //     x + y
-        let nested_let_expr = Arc::new(Expr::Let(
+        let nested_let_expr = Arc::new(Expr::new(Let(
             "x".to_string(),
             lit_expr(int(10)),
-            Arc::new(Expr::Let(
+            Arc::new(Expr::new(Let(
                 "y".to_string(),
-                Arc::new(Expr::Binary(ref_expr("x"), BinOp::Mul, lit_expr(int(2)))),
-                Arc::new(Expr::Binary(ref_expr("x"), BinOp::Add, ref_expr("y"))),
-            )),
-        ));
+                Arc::new(Expr::new(Binary(
+                    ref_expr("x"),
+                    BinOp::Mul,
+                    lit_expr(int(2)),
+                ))),
+                Arc::new(Expr::new(Binary(ref_expr("x"), BinOp::Add, ref_expr("y")))),
+            ))),
+        )));
 
         let results = evaluate_and_collect(nested_let_expr, engine, harness).await;
 
@@ -482,17 +503,17 @@ mod tests {
         // Define a function: fn(x, y) => x + y
         let add_function = Value(CoreData::Function(FunKind::Closure(
             vec!["x".to_string(), "y".to_string()],
-            Arc::new(Expr::Binary(ref_expr("x"), BinOp::Add, ref_expr("y"))),
+            Arc::new(Expr::new(Binary(ref_expr("x"), BinOp::Add, ref_expr("y")))),
         )));
 
         ctx.bind("add".to_string(), add_function);
         let engine = Engine::new(ctx);
 
         // Call the function: add(10, 20)
-        let call_expr = Arc::new(Expr::Call(
+        let call_expr = Arc::new(Expr::new(Call(
             ref_expr("add"),
             vec![lit_expr(int(10)), lit_expr(int(20))],
-        ));
+        )));
 
         let results = evaluate_and_collect(call_expr, engine, harness).await;
 
@@ -531,16 +552,16 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Call the function: sum([1, 2, 3, 4, 5])
-        let call_expr = Arc::new(Expr::Call(
+        let call_expr = Arc::new(Expr::new(Call(
             ref_expr("sum"),
-            vec![Arc::new(Expr::CoreVal(array_val(vec![
+            vec![Arc::new(Expr::new(CoreVal(array_val(vec![
                 lit_val(int(1)),
                 lit_val(int(2)),
                 lit_val(int(3)),
                 lit_val(int(4)),
                 lit_val(int(5)),
-            ])))],
-        ));
+            ]))))],
+        )));
 
         let results = evaluate_and_collect(call_expr, engine, harness).await;
 
@@ -562,26 +583,26 @@ mod tests {
         // Define a function to compute factorial: fn(n) => if n <= 1 then 1 else n * factorial(n-1)
         let factorial_function = Value(CoreData::Function(FunKind::Closure(
             vec!["n".to_string()],
-            Arc::new(Expr::IfThenElse(
-                Arc::new(Expr::Binary(
+            Arc::new(Expr::new(IfThenElse(
+                Arc::new(Expr::new(Binary(
                     ref_expr("n"),
                     BinOp::Lt,
                     lit_expr(int(2)), // n < 2
-                )),
+                ))),
                 lit_expr(int(1)), // then 1
-                Arc::new(Expr::Binary(
+                Arc::new(Expr::new(Binary(
                     ref_expr("n"),
                     BinOp::Mul,
-                    Arc::new(Expr::Call(
+                    Arc::new(Expr::new(Call(
                         ref_expr("factorial"),
-                        vec![Arc::new(Expr::Binary(
+                        vec![Arc::new(Expr::new(Binary(
                             ref_expr("n"),
                             BinOp::Sub,
                             lit_expr(int(1)),
-                        ))],
-                    )),
-                )), // else n * factorial(n-1)
-            )),
+                        )))],
+                    ))),
+                ))), // else n * factorial(n-1)
+            ))),
         )));
 
         ctx.bind("factorial".to_string(), factorial_function);
@@ -591,19 +612,23 @@ mod tests {
         // 1. Defines variables for different values
         // 2. Calls factorial on one of them
         // 3. Performs some arithmetic on the result
-        let program = Arc::new(Expr::Let(
+        let program = Arc::new(Expr::new(Let(
             "a".to_string(),
             lit_expr(int(5)), // a = 5
-            Arc::new(Expr::Let(
+            Arc::new(Expr::new(Let(
                 "b".to_string(),
                 lit_expr(int(3)), // b = 3
-                Arc::new(Expr::Let(
+                Arc::new(Expr::new(Let(
                     "fact_a".to_string(),
-                    Arc::new(Expr::Call(ref_expr("factorial"), vec![ref_expr("a")])), // fact_a = factorial(a)
-                    Arc::new(Expr::Binary(ref_expr("fact_a"), BinOp::Div, ref_expr("b"))), // fact_a / b
-                )),
-            )),
-        ));
+                    Arc::new(Expr::new(Call(ref_expr("factorial"), vec![ref_expr("a")]))), // fact_a = factorial(a)
+                    Arc::new(Expr::new(Binary(
+                        ref_expr("fact_a"),
+                        BinOp::Div,
+                        ref_expr("b"),
+                    ))), // fact_a / b
+                ))),
+            ))),
+        )));
 
         let results = evaluate_and_collect(program, engine, harness).await;
 
@@ -630,11 +655,11 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Reference to a variable in the current (inner) scope
-        let inner_ref = Arc::new(Expr::Ref("inner_var".to_string()));
+        let inner_ref = Arc::new(Expr::new(Ref("inner_var".to_string())));
         let inner_results = evaluate_and_collect(inner_ref, engine.clone(), harness.clone()).await;
 
         // Reference to a variable in the outer scope
-        let outer_ref = Arc::new(Expr::Ref("outer_var".to_string()));
+        let outer_ref = Arc::new(Expr::new(Ref("outer_var".to_string())));
         let outer_results = evaluate_and_collect(outer_ref, engine.clone(), harness).await;
 
         // Check results

--- a/optd-dsl/src/engine/eval/match.rs
+++ b/optd-dsl/src/engine/eval/match.rs
@@ -533,12 +533,13 @@ mod tests {
         analyzer::{
             context::Context,
             hir::{
-                BinOp, CoreData, Expr, FunKind, Goal, GroupId, Literal, LogicalOp, Materializable,
-                Operator, Value,
+                BinOp, CoreData, Expr, ExprKind, FunKind, Goal, GroupId, Literal, LogicalOp,
+                Materializable, Operator, Value,
             },
         },
         engine::test_utils::TestHarness,
     };
+    use ExprKind::*;
     use Materializable::*;
     use std::sync::Arc;
 
@@ -588,11 +589,15 @@ mod tests {
             vec![
                 match_arm(
                     bind_pattern("x", literal_pattern(int(42))),
-                    Arc::new(Expr::Let(
+                    Arc::new(Expr::new(Let(
                         "y".to_string(),
-                        Arc::new(Expr::Binary(ref_expr("x"), BinOp::Add, lit_expr(int(10)))),
+                        Arc::new(Expr::new(Binary(
+                            ref_expr("x"),
+                            BinOp::Add,
+                            lit_expr(int(10)),
+                        ))),
                         ref_expr("y"),
-                    )),
+                    ))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(int(0))),
             ],
@@ -617,13 +622,13 @@ mod tests {
         let harness = TestHarness::new();
 
         // Create an array value [1, 2, 3, 4, 5]
-        let array_expr = Arc::new(Expr::CoreVal(array_val(vec![
+        let array_expr = Arc::new(Expr::new(CoreVal(array_val(vec![
             lit_val(int(1)),
             lit_val(int(2)),
             lit_val(int(3)),
             lit_val(int(4)),
             lit_val(int(5)),
-        ])));
+        ]))));
 
         // Create a match expression:
         // match [1, 2, 3, 4, 5] {
@@ -641,11 +646,11 @@ mod tests {
                         bind_pattern("head", literal_pattern(int(1))),
                         bind_pattern("tail", wildcard_pattern()),
                     ),
-                    Arc::new(Expr::Binary(
+                    Arc::new(Expr::new(Binary(
                         ref_expr("head"),
                         BinOp::Add,
-                        Arc::new(Expr::Call(ref_expr("length"), vec![ref_expr("tail")])),
-                    )),
+                        Arc::new(Expr::new(Call(ref_expr("length"), vec![ref_expr("tail")]))),
+                    ))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(int(0))),
             ],
@@ -688,10 +693,10 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a struct value Point { x: 10, y: 20 }
-        let struct_expr = Arc::new(Expr::CoreVal(struct_val(
+        let struct_expr = Arc::new(Expr::new(CoreVal(struct_val(
             "Point",
             vec![lit_val(int(10)), lit_val(int(20))],
-        )));
+        ))));
 
         // Create a match expression:
         // match Point { x: 10, y: 20 } {
@@ -709,7 +714,7 @@ mod tests {
                             bind_pattern("y", wildcard_pattern()),
                         ],
                     ),
-                    Arc::new(Expr::Binary(ref_expr("x"), BinOp::Add, ref_expr("y"))),
+                    Arc::new(Expr::new(Binary(ref_expr("x"), BinOp::Add, ref_expr("y")))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(int(0))),
             ],
@@ -746,7 +751,7 @@ mod tests {
         };
 
         let logical_op_value = Value(CoreData::Logical(Materialized(LogicalOp::logical(op))));
-        let logical_op_expr = Arc::new(Expr::CoreVal(logical_op_value.clone()));
+        let logical_op_expr = Arc::new(Expr::new(CoreVal(logical_op_value.clone())));
 
         // Create a match expression:
         // match LogicalJoin { joinType: "inner", condition } [TableScan(left), TableScan(right)] {
@@ -782,27 +787,27 @@ mod tests {
                         ],
                     ),
                     // Create a complex expression to concatenate strings
-                    Arc::new(Expr::Binary(
-                        Arc::new(Expr::Binary(
-                            Arc::new(Expr::Binary(
-                                Arc::new(Expr::Binary(
+                    Arc::new(Expr::new(Binary(
+                        Arc::new(Expr::new(Binary(
+                            Arc::new(Expr::new(Binary(
+                                Arc::new(Expr::new(Binary(
                                     lit_expr(string("Found inner join between ")),
                                     BinOp::Concat,
                                     ref_expr("left"),
-                                )),
+                                ))),
                                 BinOp::Concat,
                                 lit_expr(string(" and ")),
-                            )),
+                            ))),
                             BinOp::Concat,
                             ref_expr("right"),
-                        )),
+                        ))),
                         BinOp::Concat,
-                        Arc::new(Expr::Binary(
+                        Arc::new(Expr::new(Binary(
                             lit_expr(string(" with condition: ")),
                             BinOp::Concat,
                             ref_expr("condition"),
-                        )),
-                    )),
+                        ))),
+                    ))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(string("No match"))),
             ],
@@ -849,7 +854,7 @@ mod tests {
         // Create an unmaterialized logical operator
         let unmaterialized_logical_op = Value(CoreData::Logical(UnMaterialized(test_group_id)));
 
-        let unmaterialized_expr = Arc::new(Expr::CoreVal(unmaterialized_logical_op));
+        let unmaterialized_expr = Arc::new(Expr::new(CoreVal(unmaterialized_logical_op)));
 
         // Create a match expression:
         // match UnMaterializedLogicalOp(group_id) {
@@ -885,27 +890,27 @@ mod tests {
                         ],
                     ),
                     // Create a complex expression to concatenate strings
-                    Arc::new(Expr::Binary(
-                        Arc::new(Expr::Binary(
-                            Arc::new(Expr::Binary(
-                                Arc::new(Expr::Binary(
+                    Arc::new(Expr::new(Binary(
+                        Arc::new(Expr::new(Binary(
+                            Arc::new(Expr::new(Binary(
+                                Arc::new(Expr::new(Binary(
                                     lit_expr(string("Resolved group: found inner join between ")),
                                     BinOp::Concat,
                                     ref_expr("left"),
-                                )),
+                                ))),
                                 BinOp::Concat,
                                 lit_expr(string(" and ")),
-                            )),
+                            ))),
                             BinOp::Concat,
                             ref_expr("right"),
-                        )),
+                        ))),
                         BinOp::Concat,
-                        Arc::new(Expr::Binary(
+                        Arc::new(Expr::new(Binary(
                             lit_expr(string(" with condition: ")),
                             BinOp::Concat,
                             ref_expr("condition"),
-                        )),
-                    )),
+                        ))),
+                    ))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(string("No match"))),
             ],
@@ -960,7 +965,7 @@ mod tests {
         // Create an unmaterialized physical operator with the goal
         let unmaterialized_physical_op = Value(CoreData::Physical(UnMaterialized(test_goal)));
 
-        let unmaterialized_expr = Arc::new(Expr::CoreVal(unmaterialized_physical_op));
+        let unmaterialized_expr = Arc::new(Expr::new(CoreVal(unmaterialized_physical_op)));
 
         // Create a match expression to match against the expanded physical operator
         let match_expr = pattern_match_expr(
@@ -987,49 +992,49 @@ mod tests {
                         ],
                     ),
                     // Create formatted result string with binding values
-                    Arc::new(Expr::Let(
+                    Arc::new(Expr::new(Let(
                         "to_string".to_string(),
-                        Arc::new(Expr::CoreVal(Value(CoreData::Function(FunKind::RustUDF(
-                            |args| match &args[0].0 {
+                        Arc::new(Expr::new(CoreVal(Value(CoreData::Function(
+                            FunKind::RustUDF(|args| match &args[0].0 {
                                 CoreData::Literal(lit) => {
                                     Value(CoreData::Literal(string(&format!("{:?}", lit))))
                                 }
                                 _ => Value(CoreData::Literal(string("<non-literal>"))),
-                            },
+                            }),
                         ))))),
-                        Arc::new(Expr::Binary(
+                        Arc::new(Expr::new(Binary(
                             lit_expr(string("Physical plan: ")),
                             BinOp::Concat,
-                            Arc::new(Expr::Binary(
-                                Arc::new(Expr::Call(
+                            Arc::new(Expr::new(Binary(
+                                Arc::new(Expr::new(Call(
                                     ref_expr("to_string"),
                                     vec![ref_expr("join_method")],
-                                )),
+                                ))),
                                 BinOp::Concat,
-                                Arc::new(Expr::Binary(
+                                Arc::new(Expr::new(Binary(
                                     lit_expr(string(" join between ")),
                                     BinOp::Concat,
-                                    Arc::new(Expr::Binary(
+                                    Arc::new(Expr::new(Binary(
                                         ref_expr("left_table"),
                                         BinOp::Concat,
-                                        Arc::new(Expr::Binary(
+                                        Arc::new(Expr::new(Binary(
                                             lit_expr(string(" and ")),
                                             BinOp::Concat,
-                                            Arc::new(Expr::Binary(
+                                            Arc::new(Expr::new(Binary(
                                                 ref_expr("right_table"),
                                                 BinOp::Concat,
-                                                Arc::new(Expr::Binary(
+                                                Arc::new(Expr::new(Binary(
                                                     lit_expr(string(" with condition: ")),
                                                     BinOp::Concat,
                                                     ref_expr("join_condition"),
-                                                )),
-                                            )),
-                                        )),
-                                    )),
-                                )),
-                            )),
-                        )),
-                    )),
+                                                ))),
+                                            ))),
+                                        ))),
+                                    ))),
+                                ))),
+                            ))),
+                        ))),
+                    ))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(string("No match"))),
             ],
@@ -1085,10 +1090,10 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a struct value Point { x: 30, y: 40 }
-        let struct_expr = Arc::new(Expr::CoreVal(struct_val(
+        let struct_expr = Arc::new(Expr::new(CoreVal(struct_val(
             "Point",
             vec![lit_val(int(30)), lit_val(int(40))],
-        )));
+        ))));
 
         // Create a match expression with multiple arms and fallthrough:
         // match Point { x: 30, y: 40 } {
@@ -1109,19 +1114,22 @@ mod tests {
                             bind_pattern("y", wildcard_pattern()),
                         ],
                     ),
-                    Arc::new(Expr::Binary(
+                    Arc::new(Expr::new(Binary(
                         lit_expr(string("First arm: ")),
                         BinOp::Concat,
-                        Arc::new(Expr::Binary(
-                            Arc::new(Expr::Call(ref_expr("to_string"), vec![ref_expr("x")])),
+                        Arc::new(Expr::new(Binary(
+                            Arc::new(Expr::new(Call(ref_expr("to_string"), vec![ref_expr("x")]))),
                             BinOp::Concat,
-                            Arc::new(Expr::Binary(
+                            Arc::new(Expr::new(Binary(
                                 lit_expr(string(", ")),
                                 BinOp::Concat,
-                                Arc::new(Expr::Call(ref_expr("to_string"), vec![ref_expr("y")])),
-                            )),
-                        )),
-                    )),
+                                Arc::new(Expr::new(Call(
+                                    ref_expr("to_string"),
+                                    vec![ref_expr("y")],
+                                ))),
+                            ))),
+                        ))),
+                    ))),
                 ),
                 // Second arm - won't match
                 match_arm(
@@ -1132,19 +1140,22 @@ mod tests {
                             bind_pattern("y", wildcard_pattern()),
                         ],
                     ),
-                    Arc::new(Expr::Binary(
+                    Arc::new(Expr::new(Binary(
                         lit_expr(string("Second arm: ")),
                         BinOp::Concat,
-                        Arc::new(Expr::Binary(
-                            Arc::new(Expr::Call(ref_expr("to_string"), vec![ref_expr("x")])),
+                        Arc::new(Expr::new(Binary(
+                            Arc::new(Expr::new(Call(ref_expr("to_string"), vec![ref_expr("x")]))),
                             BinOp::Concat,
-                            Arc::new(Expr::Binary(
+                            Arc::new(Expr::new(Binary(
                                 lit_expr(string(", ")),
                                 BinOp::Concat,
-                                Arc::new(Expr::Call(ref_expr("to_string"), vec![ref_expr("y")])),
-                            )),
-                        )),
-                    )),
+                                Arc::new(Expr::new(Call(
+                                    ref_expr("to_string"),
+                                    vec![ref_expr("y")],
+                                ))),
+                            ))),
+                        ))),
+                    ))),
                 ),
                 // Fallthrough arm - should match
                 match_arm(
@@ -1155,19 +1166,22 @@ mod tests {
                             bind_pattern("y", wildcard_pattern()),
                         ],
                     ),
-                    Arc::new(Expr::Binary(
+                    Arc::new(Expr::new(Binary(
                         lit_expr(string("Fallthrough arm: ")),
                         BinOp::Concat,
-                        Arc::new(Expr::Binary(
-                            Arc::new(Expr::Call(ref_expr("to_string"), vec![ref_expr("x")])),
+                        Arc::new(Expr::new(Binary(
+                            Arc::new(Expr::new(Call(ref_expr("to_string"), vec![ref_expr("x")]))),
                             BinOp::Concat,
-                            Arc::new(Expr::Binary(
+                            Arc::new(Expr::new(Binary(
                                 lit_expr(string(", ")),
                                 BinOp::Concat,
-                                Arc::new(Expr::Call(ref_expr("to_string"), vec![ref_expr("y")])),
-                            )),
-                        )),
-                    )),
+                                Arc::new(Expr::new(Call(
+                                    ref_expr("to_string"),
+                                    vec![ref_expr("y")],
+                                ))),
+                            ))),
+                        ))),
+                    ))),
                 ),
                 // Default arm - won't reach
                 match_arm(wildcard_pattern(), lit_expr(string("Default"))),
@@ -1246,7 +1260,7 @@ mod tests {
             )],
         );
 
-        let nested_op_expr = Arc::new(Expr::CoreVal(nested_op));
+        let nested_op_expr = Arc::new(Expr::new(CoreVal(nested_op)));
 
         // Create a deeply nested pattern match that extracts values at various depths:
         let match_expr = pattern_match_expr(
@@ -1281,49 +1295,52 @@ mod tests {
                         )],
                     ),
                     // Build a SQL-like string with to_string calls
-                    Arc::new(Expr::Binary(
+                    Arc::new(Expr::new(Binary(
                         lit_expr(string("Query: SELECT ")),
                         BinOp::Concat,
-                        Arc::new(Expr::Binary(
-                            Arc::new(Expr::Call(ref_expr("to_string"), vec![ref_expr("cols")])),
+                        Arc::new(Expr::new(Binary(
+                            Arc::new(Expr::new(Call(
+                                ref_expr("to_string"),
+                                vec![ref_expr("cols")],
+                            ))),
                             BinOp::Concat,
-                            Arc::new(Expr::Binary(
+                            Arc::new(Expr::new(Binary(
                                 lit_expr(string(" FROM ")),
                                 BinOp::Concat,
-                                Arc::new(Expr::Binary(
-                                    Arc::new(Expr::Call(
+                                Arc::new(Expr::new(Binary(
+                                    Arc::new(Expr::new(Call(
                                         ref_expr("to_string"),
                                         vec![ref_expr("t1")],
-                                    )),
+                                    ))),
                                     BinOp::Concat,
-                                    Arc::new(Expr::Binary(
+                                    Arc::new(Expr::new(Binary(
                                         lit_expr(string(" JOIN ")),
                                         BinOp::Concat,
-                                        Arc::new(Expr::Binary(
-                                            Arc::new(Expr::Call(
+                                        Arc::new(Expr::new(Binary(
+                                            Arc::new(Expr::new(Call(
                                                 ref_expr("to_string"),
                                                 vec![ref_expr("t2")],
-                                            )),
+                                            ))),
                                             BinOp::Concat,
-                                            Arc::new(Expr::Binary(
+                                            Arc::new(Expr::new(Binary(
                                                 lit_expr(string(" ON ")),
                                                 BinOp::Concat,
-                                                Arc::new(Expr::Binary(
+                                                Arc::new(Expr::new(Binary(
                                                     ref_expr("jcond"),
                                                     BinOp::Concat,
-                                                    Arc::new(Expr::Binary(
+                                                    Arc::new(Expr::new(Binary(
                                                         lit_expr(string(" WHERE ")),
                                                         BinOp::Concat,
                                                         ref_expr("pred"),
-                                                    )),
-                                                )),
-                                            )),
-                                        )),
-                                    )),
-                                )),
-                            )),
-                        )),
-                    )),
+                                                    ))),
+                                                ))),
+                                            ))),
+                                        ))),
+                                    ))),
+                                ))),
+                            ))),
+                        ))),
+                    ))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(string("No match"))),
             ],
@@ -1405,7 +1422,7 @@ mod tests {
             ],
         );
 
-        let join_expr = Arc::new(Expr::CoreVal(join_op));
+        let join_expr = Arc::new(Expr::new(CoreVal(join_op)));
 
         // Create a pattern match that will match any join with a table scan as first child
         // and extract information from it
@@ -1432,19 +1449,19 @@ mod tests {
                             ),
                         ],
                     ),
-                    Arc::new(Expr::Let(
+                    Arc::new(Expr::new(Let(
                         "result".to_string(),
-                        Arc::new(Expr::Binary(
+                        Arc::new(Expr::new(Binary(
                             ref_expr("table_name"),
                             BinOp::Concat,
-                            Arc::new(Expr::Binary(
+                            Arc::new(Expr::new(Binary(
                                 lit_expr(string(" filtered by ")),
                                 BinOp::Concat,
                                 ref_expr("filter_condition"),
-                            )),
-                        )),
+                            ))),
+                        ))),
                         ref_expr("result"),
-                    )),
+                    ))),
                 ),
                 match_arm(wildcard_pattern(), lit_expr(string("No match"))),
             ],

--- a/optd-dsl/src/engine/eval/operator.rs
+++ b/optd-dsl/src/engine/eval/operator.rs
@@ -148,8 +148,8 @@ mod tests {
     use crate::analyzer::{
         context::Context,
         hir::{
-            BinOp, CoreData, Expr, Goal, GroupId, Literal, LogicalOp, Materializable, Operator,
-            PhysicalOp, Value,
+            BinOp, CoreData, Expr, ExprKind, Goal, GroupId, Literal, LogicalOp, Materializable,
+            Operator, PhysicalOp, Value,
         },
     };
     use crate::engine::{
@@ -159,6 +159,7 @@ mod tests {
             string,
         },
     };
+    use ExprKind::*;
     use std::sync::Arc;
 
     /// Test evaluation of a materialized logical operator
@@ -173,22 +174,22 @@ mod tests {
             tag: "Join".to_string(),
             data: vec![
                 lit_expr(string("inner")),
-                Arc::new(Expr::Binary(
+                Arc::new(Expr::new(Binary(
                     lit_expr(int(10)),
                     BinOp::Add,
                     lit_expr(int(5)),
-                )),
+                ))),
             ],
             children: vec![
-                Arc::new(Expr::CoreExpr(CoreData::Literal(string("orders")))),
-                Arc::new(Expr::CoreExpr(CoreData::Literal(string("lineitem")))),
+                Arc::new(Expr::new(CoreExpr(CoreData::Literal(string("orders"))))),
+                Arc::new(Expr::new(CoreExpr(CoreData::Literal(string("lineitem"))))),
             ],
         });
 
         // Create the expression to evaluate
-        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(
+        let logical_op_expr = Arc::new(Expr::new(CoreExpr(CoreData::Logical(
             Materializable::Materialized(log_op),
-        )));
+        ))));
 
         // Evaluate the expression
         let results = evaluate_and_collect(logical_op_expr, engine, harness).await;
@@ -245,9 +246,9 @@ mod tests {
         let group_id = GroupId(42);
 
         // Create the expression to evaluate
-        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(
+        let logical_op_expr = Arc::new(Expr::new(CoreExpr(CoreData::Logical(
             Materializable::UnMaterialized(group_id),
-        )));
+        ))));
 
         // Evaluate the expression
         let results = evaluate_and_collect(logical_op_expr, engine, harness).await;
@@ -275,22 +276,22 @@ mod tests {
             tag: "HashJoin".to_string(),
             data: vec![
                 lit_expr(string("inner")),
-                Arc::new(Expr::Binary(
+                Arc::new(Expr::new(Binary(
                     lit_expr(int(20)),
                     BinOp::Mul,
                     lit_expr(int(3)),
-                )),
+                ))),
             ],
             children: vec![
-                Arc::new(Expr::CoreExpr(CoreData::Literal(string("IndexScan")))),
-                Arc::new(Expr::CoreExpr(CoreData::Literal(string("FullScan")))),
+                Arc::new(Expr::new(CoreExpr(CoreData::Literal(string("IndexScan"))))),
+                Arc::new(Expr::new(CoreExpr(CoreData::Literal(string("FullScan"))))),
             ],
         });
 
         // Create the expression to evaluate
-        let physical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Physical(
+        let physical_op_expr = Arc::new(Expr::new(CoreExpr(CoreData::Physical(
             Materializable::Materialized(phys_op),
-        )));
+        ))));
 
         // Evaluate the expression
         let results = evaluate_and_collect(physical_op_expr, engine, harness).await;
@@ -352,9 +353,9 @@ mod tests {
         };
 
         // Create the expression to evaluate
-        let physical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Physical(
+        let physical_op_expr = Arc::new(Expr::new(CoreExpr(CoreData::Physical(
             Materializable::UnMaterialized(goal.clone()),
-        )));
+        ))));
 
         // Evaluate the expression
         let results = evaluate_and_collect(physical_op_expr, engine, harness).await;
@@ -386,17 +387,17 @@ mod tests {
         let engine = Engine::new(ctx);
 
         // Create a Join operator with two Scan operators as children
-        let scan1 = Arc::new(Expr::CoreVal(create_logical_operator(
+        let scan1 = Arc::new(Expr::new(CoreVal(create_logical_operator(
             "Scan",
             vec![lit_val(string("orders"))],
             vec![],
-        )));
+        ))));
 
-        let scan2 = Arc::new(Expr::CoreVal(create_logical_operator(
+        let scan2 = Arc::new(Expr::new(CoreVal(create_logical_operator(
             "Scan",
             vec![lit_val(string("lineitem"))],
             vec![],
-        )));
+        ))));
 
         let log_op = LogicalOp::logical(Operator {
             tag: "Join".to_string(),
@@ -405,9 +406,9 @@ mod tests {
         });
 
         // Create the expression to evaluate
-        let logical_op_expr = Arc::new(Expr::CoreExpr(CoreData::Logical(
+        let logical_op_expr = Arc::new(Expr::new(CoreExpr(CoreData::Logical(
             Materializable::Materialized(log_op),
-        )));
+        ))));
 
         // Evaluate the expression
         let results = evaluate_and_collect(logical_op_expr, engine, harness).await;

--- a/optd-dsl/src/engine/mod.rs
+++ b/optd-dsl/src/engine/mod.rs
@@ -1,7 +1,8 @@
 use crate::analyzer::{
     context::Context,
-    hir::{Expr, Goal, GroupId, Value},
+    hir::{Expr, ExprKind, Goal, GroupId, Value},
 };
+use ExprKind::*;
 use eval::core::evaluate_core_expr;
 use eval::expr::{
     evaluate_binary_expr, evaluate_function_call, evaluate_if_then_else, evaluate_let_binding,
@@ -75,11 +76,11 @@ impl Engine {
         O: Send + 'static,
     {
         Box::pin(async move {
-            match expr.as_ref() {
-                Expr::PatternMatch(expr, match_arms) => {
-                    evaluate_pattern_match(expr.clone(), match_arms.clone(), self, k).await
+            match &expr.as_ref().kind {
+                PatternMatch(sub_expr, match_arms) => {
+                    evaluate_pattern_match(sub_expr.clone(), match_arms.clone(), self, k).await
                 }
-                Expr::IfThenElse(cond, then_expr, else_expr) => {
+                IfThenElse(cond, then_expr, else_expr) => {
                     evaluate_if_then_else(
                         cond.clone(),
                         then_expr.clone(),
@@ -89,22 +90,18 @@ impl Engine {
                     )
                     .await
                 }
-                Expr::Let(ident, assignee, after) => {
+                Let(ident, assignee, after) => {
                     evaluate_let_binding(ident.clone(), assignee.clone(), after.clone(), self, k)
                         .await
                 }
-                Expr::Binary(left, op, right) => {
+                Binary(left, op, right) => {
                     evaluate_binary_expr(left.clone(), op.clone(), right.clone(), self, k).await
                 }
-                Expr::Unary(op, expr) => {
-                    evaluate_unary_expr(op.clone(), expr.clone(), self, k).await
-                }
-                Expr::Call(fun, args) => {
-                    evaluate_function_call(fun.clone(), args.clone(), self, k).await
-                }
-                Expr::Ref(ident) => evaluate_reference(ident.clone(), self, k).await,
-                Expr::CoreExpr(expr) => evaluate_core_expr(expr.clone(), self, k).await,
-                Expr::CoreVal(val) => k(val.clone()).await,
+                Unary(op, expr) => evaluate_unary_expr(op.clone(), expr.clone(), self, k).await,
+                Call(fun, args) => evaluate_function_call(fun.clone(), args.clone(), self, k).await,
+                Ref(ident) => evaluate_reference(ident.clone(), self, k).await,
+                CoreExpr(expr) => evaluate_core_expr(expr.clone(), self, k).await,
+                CoreVal(val) => k(val.clone()).await,
             }
         })
     }
@@ -149,12 +146,12 @@ impl Engine {
     /// # Returns
     /// A call expression representing the rule invocation
     fn create_rule_call(&self, rule_name: &str, args: Vec<Value>) -> Arc<Expr> {
-        let rule_name_expr = Expr::Ref(rule_name.to_string());
+        let rule_name_expr = Expr::new(Ref(rule_name.to_string())).into();
         let arg_exprs = args
             .into_iter()
-            .map(|arg| Expr::CoreVal(arg).into())
+            .map(|arg| Expr::new(CoreVal(arg)).into())
             .collect();
 
-        Expr::Call(rule_name_expr.into(), arg_exprs).into()
+        Expr::new(Call(rule_name_expr, arg_exprs)).into()
     }
 }

--- a/optd-dsl/src/engine/test_utils.rs
+++ b/optd-dsl/src/engine/test_utils.rs
@@ -1,7 +1,7 @@
 use super::{Continuation, EngineResponse};
 use crate::analyzer::hir::{
-    CoreData, Expr, Goal, GroupId, Literal, LogicalOp, MatchArm, Materializable, Operator, Pattern,
-    PhysicalOp, Value,
+    CoreData, Expr, ExprKind, Goal, GroupId, Literal, LogicalOp, MatchArm, Materializable,
+    Operator, Pattern, PhysicalOp, Value,
 };
 use crate::engine::Engine;
 use Materializable::*;
@@ -84,7 +84,7 @@ impl TestHarness {
 
 /// Helper to create a literal expression.
 pub fn lit_expr(literal: Literal) -> Arc<Expr> {
-    Arc::new(Expr::CoreExpr(CoreData::Literal(literal)))
+    Arc::new(Expr::new(ExprKind::CoreExpr(CoreData::Literal(literal))))
 }
 
 /// Helper to create a literal value.
@@ -109,7 +109,7 @@ pub fn boolean(b: bool) -> Literal {
 
 /// Helper to create a reference expression.
 pub fn ref_expr(name: &str) -> Arc<Expr> {
-    Arc::new(Expr::Ref(name.to_string()))
+    Arc::new(Expr::new(ExprKind::Ref(name.to_string())))
 }
 
 /// Helper to create a pattern match arm.
@@ -129,7 +129,7 @@ pub fn struct_val(name: &str, fields: Vec<Value>) -> Value {
 
 /// Helper to create a pattern matching expression.
 pub fn pattern_match_expr(expr: Arc<Expr>, arms: Vec<MatchArm>) -> Arc<Expr> {
-    Arc::new(Expr::PatternMatch(expr, arms))
+    Arc::new(Expr::new(ExprKind::PatternMatch(expr, arms)))
 }
 
 /// Helper to create a bind pattern.


### PR DESCRIPTION
## Problem

Setup code for the analyzer. The `HIR` gets wrapped with a metadata field.

Illustration:

```rust
/// Metadata that can be attached to expression nodes
///
/// This trait allows for different types of metadata to be attached to
/// expression nodes while maintaining a common interface for access.
pub trait ExprMetadata: Debug + Clone {}

/// Empty metadata implementation for cases where no additional data is needed
pub struct NoMetadata;

/// Combined span and type information for an expression
pub struct TypedSpan {
    /// Source code location.
    pub span: Span,
    /// Inferred type.
    pub ty: Type,
}

/// Expression nodes in the HIR with optional metadata
///
/// The M type parameter allows attaching different kinds of metadata to expressions,
/// such as type information, source spans, or both.
pub struct Expr<M: ExprMetadata = NoMetadata> {
    /// The actual expression node
    pub kind: ExprKind<M>,
    /// Optional metadata for the expression
    pub metadata: M,
}
```

## Summary of changes

Adapted the engine to take EmptyMetadata (no functional changes), all relevant code to review is in HIR.
The critical pass is that the metadata is all we should need to perform type checking and inference.

This PR is dependent on #51 