### PR TITLE
(feat) Integrate Block Scoping

### DIFF
--- a/optd-dsl/src/analyzer/from_ast/expr.rs
+++ b/optd-dsl/src/analyzer/from_ast/expr.rs
@@ -61,6 +61,7 @@ pub(super) fn convert_expr(
         }
         ast::Expr::Postfix(expr, op) => convert_postfix(expr, op, generics)?,
         ast::Expr::Fail(error_expr) => convert_fail(error_expr, generics)?,
+        ast::Expr::Block(block) => convert_block(block, generics)?,
     };
 
     Ok(Expr::new_with(kind, ty, span))
@@ -349,6 +350,16 @@ fn convert_fail(
     let hir_error = convert_expr(error_expr, generics)?;
 
     Ok(CoreExpr(CoreData::Fail(Box::new(Arc::new(hir_error)))))
+}
+
+/// Converts a block expression to an HIR expression kind.
+fn convert_block(
+    block: &Spanned<ast::Expr>,
+    generics: &HashSet<Identifier>,
+) -> Result<ExprKind<TypedSpan>, SemanticErrorKind> {
+    let hir_expr = convert_expr(&block, generics)?;
+
+    Ok(NewScope(hir_expr.into()))
 }
 
 #[cfg(test)]
@@ -837,6 +848,30 @@ mod expr_tests {
                 }
             }
             _ => panic!("Expected PatternMatch expression"),
+        }
+    }
+
+    #[test]
+    fn test_convert_block() {
+        // Create a simple expression inside a block
+        let inner_expr = spanned(ast::Expr::Literal(ast::Literal::Int64(42)));
+        let block_expr = spanned(ast::Expr::Block(inner_expr));
+
+        let result = convert_expr(&block_expr, &HashSet::new()).unwrap();
+
+        // Check that the block is converted to a NewScope expression
+        match &result.kind {
+            ExprKind::NewScope(expr) => {
+                // Verify the inner expression
+                match &expr.kind {
+                    ExprKind::CoreVal(value) => match &value.data {
+                        CoreData::Literal(Literal::Int64(val)) => assert_eq!(*val, 42),
+                        _ => panic!("Expected Int64 literal inside block"),
+                    },
+                    _ => panic!("Expected CoreVal inside block"),
+                }
+            }
+            _ => panic!("Expected NewScope expression"),
         }
     }
 

--- a/optd-dsl/src/analyzer/from_ast/expr.rs
+++ b/optd-dsl/src/analyzer/from_ast/expr.rs
@@ -357,7 +357,7 @@ fn convert_block(
     block: &Spanned<ast::Expr>,
     generics: &HashSet<Identifier>,
 ) -> Result<ExprKind<TypedSpan>, SemanticErrorKind> {
-    let hir_expr = convert_expr(&block, generics)?;
+    let hir_expr = convert_expr(block, generics)?;
 
     Ok(NewScope(hir_expr.into()))
 }

--- a/optd-dsl/src/analyzer/hir.rs
+++ b/optd-dsl/src/analyzer/hir.rs
@@ -314,6 +314,8 @@ pub enum ExprKind<M: ExprMetadata> {
     PatternMatch(Arc<Expr<M>>, Vec<MatchArm<M>>),
     /// Conditional expression
     IfThenElse(Arc<Expr<M>>, Arc<Expr<M>>, Arc<Expr<M>>),
+    /// Expression block creating a new scope
+    NewScope(Arc<Expr<M>>),
     /// Variable binding
     Let(Identifier, Arc<Expr<M>>, Arc<Expr<M>>),
     /// Binary operation

--- a/optd-dsl/src/analyzer/semantic_check/scope_check.rs
+++ b/optd-dsl/src/analyzer/semantic_check/scope_check.rs
@@ -66,46 +66,6 @@ fn check_expr(
 
     let span = &expr.metadata.span;
     match &expr.kind {
-        Ref(name) => {
-            // Verify variable references exist.
-            if ctx.lookup(name).is_none() {
-                return Err(SemanticErrorKind::new_invalid_reference(
-                    name.to_string(),
-                    span.clone(),
-                ));
-            }
-        }
-
-        Let(name, value, body) => {
-            check_expr(value, ctx.clone())?;
-
-            // Bind the name before checking the body
-            // This simulates the lexical scoping rules.
-            let dummy = Value::new_unknown(CoreData::None, span.clone());
-            ctx.try_bind(name.to_string(), dummy)?;
-
-            check_expr(body, ctx)?;
-        }
-
-        Binary(left, _, right) => {
-            check_expr(left, ctx.clone())?;
-            check_expr(right, ctx)?;
-        }
-
-        Unary(_, operand) => check_expr(operand, ctx)?,
-
-        Call(func, args) => {
-            check_expr(func, ctx.clone())?;
-            args.iter()
-                .try_for_each(|arg| check_expr(arg, ctx.clone()))?;
-        }
-
-        IfThenElse(cond, then_branch, else_branch) => {
-            check_expr(cond, ctx.clone())?;
-            check_expr(then_branch, ctx.clone())?;
-            check_expr(else_branch, ctx)?;
-        }
-
         PatternMatch(scrutinee, arms) => {
             check_expr(scrutinee, ctx.clone())?;
 
@@ -118,16 +78,52 @@ fn check_expr(
                 check_expr(&arm.expr, arm_ctx)
             })?;
         }
+        IfThenElse(cond, then_branch, else_branch) => {
+            check_expr(cond, ctx.clone())?;
+            check_expr(then_branch, ctx.clone())?;
+            check_expr(else_branch, ctx)?;
+        }
+        NewScope(expr) => {
+            let mut new_ctx = ctx.clone();
+            new_ctx.push_scope();
+            check_expr(expr, new_ctx)?;
+        }
+        Let(name, value, body) => {
+            check_expr(value, ctx.clone())?;
 
+            // Bind the name before checking the body
+            // This simulates the lexical scoping rules.
+            let dummy = Value::new_unknown(CoreData::None, span.clone());
+            ctx.try_bind(name.to_string(), dummy)?;
+
+            check_expr(body, ctx)?;
+        }
+        Binary(left, _, right) => {
+            check_expr(left, ctx.clone())?;
+            check_expr(right, ctx)?;
+        }
+        Unary(_, operand) => check_expr(operand, ctx)?,
+        Call(func, args) => {
+            check_expr(func, ctx.clone())?;
+            args.iter()
+                .try_for_each(|arg| check_expr(arg, ctx.clone()))?;
+        }
         Map(entries) => {
             entries.iter().try_for_each(|(k, v)| {
                 check_expr(k, ctx.clone())?;
                 check_expr(v, ctx.clone())
             })?;
         }
-
+        Ref(name) => {
+            // Verify variable references exist.
+            if ctx.lookup(name).is_none() {
+                return Err(SemanticErrorKind::new_invalid_reference(
+                    name.to_string(),
+                    span.clone(),
+                ));
+            }
+        }
         FieldAccess(obj, _) => check_expr(obj, ctx)?,
-
         CoreExpr(core_data) => match core_data {
             CoreData::Array(exprs) | CoreData::Tuple(exprs) | CoreData::Struct(_, exprs) => {
                 exprs
@@ -145,7 +141,6 @@ fn check_expr(
 
             _ => {}
         },
-
         CoreVal(value) => {
             if let CoreData::Function(FunKind::Closure(params, body)) = &value.data {
                 let fn_ctx = create_function_scope(ctx, params, span)?;
@@ -216,14 +211,6 @@ mod scope_check_tests {
         Span::new("test".to_string(), start..end)
     }
 
-    // Helper to create a typed span with unknown type
-    fn unknown_span(start: usize, end: usize) -> TypedSpan {
-        TypedSpan {
-            ty: Type::Unknown,
-            span: test_span(start, end),
-        }
-    }
-
     // Create a dummy value for binding
     fn dummy_value(span: Span) -> Value<TypedSpan> {
         Value::new_unknown(CoreData::None, span)
@@ -239,7 +226,10 @@ mod scope_check_tests {
         // Create function value
         let fun_val = Value {
             data: CoreData::Function(FunKind::Closure(params, Arc::new(body))),
-            metadata: unknown_span(1, 10),
+            metadata: TypedSpan {
+                ty: Type::Unknown,
+                span: test_span(1, 10),
+            },
         };
 
         // Add function to context
@@ -257,241 +247,207 @@ mod scope_check_tests {
 
     #[test]
     fn test_valid_reference() {
-        // Create a function that references its parameter
         let param_name = "x".to_string();
-        let body = Expr {
-            kind: ExprKind::Ref(param_name.clone()),
-            metadata: unknown_span(5, 6),
-        };
-
+        let body = Expr::new_unknown(ExprKind::Ref(param_name.clone()), test_span(5, 6));
         let (_, result) = setup_test_context(vec![param_name], body);
-
-        // Should succeed
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_undefined_reference() {
-        // Create a function that references an undefined variable
-        let body = Expr {
-            kind: ExprKind::Ref("undefined".to_string()),
-            metadata: unknown_span(5, 13),
-        };
-
-        let (_, result) = setup_test_context(vec!["x".to_string()], body);
-
-        // Should fail with InvalidReference
-        assert!(matches!(result,
-            Err(SemanticErrorKind::InvalidReference { name, .. }) if name == "undefined"
-        ));
+        let (_, result) = setup_test_context(
+            vec!["x".to_string()],
+            Expr::new_unknown(ExprKind::Ref("undefined".to_string()), test_span(5, 13)),
+        );
+        assert!(
+            matches!(result, Err(SemanticErrorKind::InvalidReference { name, .. }) if name == "undefined")
+        );
     }
 
     #[test]
     fn test_let_binding() {
-        // Create let expression
         let let_var = "y".to_string();
-        let value = Expr {
-            kind: ExprKind::CoreVal(dummy_value(test_span(5, 6))),
-            metadata: unknown_span(5, 6),
-        };
-
-        let body = Expr {
-            kind: ExprKind::Ref(let_var.clone()),
-            metadata: unknown_span(7, 8),
-        };
-
-        let let_expr = Expr {
-            kind: ExprKind::Let(let_var, Arc::new(value), Arc::new(body)),
-            metadata: unknown_span(1, 10),
-        };
+        let let_expr = Expr::new_unknown(
+            ExprKind::Let(
+                let_var.clone(),
+                Arc::new(Expr::new_unknown(
+                    ExprKind::CoreVal(dummy_value(test_span(5, 6))),
+                    test_span(5, 6),
+                )),
+                Arc::new(Expr::new_unknown(ExprKind::Ref(let_var), test_span(7, 8))),
+            ),
+            test_span(1, 10),
+        );
 
         let (_, result) = setup_test_context(vec!["x".to_string()], let_expr);
-
-        // Should succeed
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_duplicate_parameters() {
-        // Create a function with duplicate parameters
-        let body = Expr {
-            kind: ExprKind::Ref("x".to_string()),
-            metadata: unknown_span(5, 6),
-        };
-
-        let (_, result) = setup_test_context(vec!["x".to_string(), "x".to_string()], body);
-
-        // Should fail with DuplicateIdentifier
-        assert!(matches!(result,
-            Err(SemanticErrorKind::DuplicateIdentifier { name, .. }) if name == "x"
-        ));
+        let (_, result) = setup_test_context(
+            vec!["x".to_string(), "x".to_string()],
+            Expr::new_unknown(ExprKind::Ref("x".to_string()), test_span(5, 6)),
+        );
+        assert!(
+            matches!(result, Err(SemanticErrorKind::DuplicateIdentifier { name, .. }) if name == "x")
+        );
     }
 
     #[test]
     fn test_duplicate_let() {
-        // Create a let that duplicates a name in the same scope
         let let_var = "y".to_string();
-
-        // First let binding
-        let value1 = Expr {
-            kind: ExprKind::CoreVal(dummy_value(test_span(5, 6))),
-            metadata: unknown_span(5, 6),
-        };
-
-        // Second let binding with the same name
-        let value2 = Expr {
-            kind: ExprKind::CoreVal(dummy_value(test_span(10, 11))),
-            metadata: unknown_span(10, 11),
-        };
-
-        let inner_body = Expr {
-            kind: ExprKind::Ref(let_var.clone()),
-            metadata: unknown_span(12, 13),
-        };
-
-        // Let y = ... in let y = ... in y
-        let inner_let = Expr {
-            kind: ExprKind::Let(let_var.clone(), Arc::new(value2), Arc::new(inner_body)),
-            metadata: unknown_span(8, 14),
-        };
-
-        let outer_let = Expr {
-            kind: ExprKind::Let(let_var, Arc::new(value1), Arc::new(inner_let)),
-            metadata: unknown_span(1, 15),
-        };
+        let outer_let = Expr::new_unknown(
+            ExprKind::Let(
+                let_var.clone(),
+                Arc::new(Expr::new_unknown(
+                    ExprKind::CoreVal(dummy_value(test_span(5, 6))),
+                    test_span(5, 6),
+                )),
+                Arc::new(Expr::new_unknown(
+                    ExprKind::Let(
+                        let_var.clone(),
+                        Arc::new(Expr::new_unknown(
+                            ExprKind::CoreVal(dummy_value(test_span(10, 11))),
+                            test_span(10, 11),
+                        )),
+                        Arc::new(Expr::new_unknown(ExprKind::Ref(let_var), test_span(12, 13))),
+                    ),
+                    test_span(8, 14),
+                )),
+            ),
+            test_span(1, 15),
+        );
 
         let (_, result) = setup_test_context(vec!["x".to_string()], outer_let);
-
-        // Should fail with DuplicateIdentifier
-        assert!(matches!(result,
-            Err(SemanticErrorKind::DuplicateIdentifier { name, .. }) if name == "y"
-        ));
+        assert!(
+            matches!(result, Err(SemanticErrorKind::DuplicateIdentifier { name, .. }) if name == "y")
+        );
     }
 
     #[test]
     fn test_nested_function() {
-        // Create a function with a nested function definition
         let outer_param = "x".to_string();
         let inner_param = "y".to_string();
 
-        // Inner function body references outer parameter
-        let inner_body = Expr {
-            kind: ExprKind::Ref(outer_param.clone()),
-            metadata: unknown_span(10, 11),
-        };
-
-        // Inner function definition
-        let inner_fn = Expr {
-            kind: ExprKind::CoreExpr(CoreData::Function(FunKind::Closure(
+        let inner_fn = Expr::new_unknown(
+            ExprKind::CoreExpr(CoreData::Function(FunKind::Closure(
                 vec![inner_param],
-                Arc::new(inner_body),
+                Arc::new(Expr::new_unknown(
+                    ExprKind::Ref(outer_param.clone()),
+                    test_span(10, 11),
+                )),
             ))),
-            metadata: unknown_span(5, 12),
-        };
+            test_span(5, 12),
+        );
 
         let (_, result) = setup_test_context(vec![outer_param], inner_fn);
-
-        // Should succeed
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_pattern_match() {
-        // Create a pattern match expression
-        let scrutinee = Expr {
-            kind: ExprKind::Ref("x".to_string()),
-            metadata: unknown_span(5, 6),
-        };
-
-        // Create a binding pattern
-        let pat_span = unknown_span(10, 15);
-        let pattern = Pattern {
-            kind: PatternKind::Bind(
-                "matched".to_string(),
-                Box::new(Pattern {
-                    kind: PatternKind::Wildcard,
-                    metadata: pat_span.clone(),
-                }),
+        let match_expr = Expr::new_unknown(
+            ExprKind::PatternMatch(
+                Arc::new(Expr::new_unknown(
+                    ExprKind::Ref("x".to_string()),
+                    test_span(5, 6),
+                )),
+                vec![MatchArm {
+                    pattern: Pattern::new_unknown(
+                        PatternKind::Bind(
+                            "matched".to_string(),
+                            Box::new(Pattern::new_unknown(
+                                PatternKind::Wildcard,
+                                test_span(10, 15),
+                            )),
+                        ),
+                        test_span(10, 15),
+                    ),
+                    expr: Arc::new(Expr::new_unknown(
+                        ExprKind::Ref("matched".to_string()),
+                        test_span(20, 27),
+                    )),
+                }],
             ),
-            metadata: pat_span,
-        };
-
-        // Match arm body references the bound variable
-        let arm_body = Expr {
-            kind: ExprKind::Ref("matched".to_string()),
-            metadata: unknown_span(20, 27),
-        };
-
-        // Create match arms
-        let arms = vec![MatchArm {
-            pattern,
-            expr: Arc::new(arm_body),
-        }];
-
-        // Create pattern match expression
-        let match_expr = Expr {
-            kind: ExprKind::PatternMatch(Arc::new(scrutinee), arms),
-            metadata: unknown_span(1, 30),
-        };
+            test_span(1, 30),
+        );
 
         let (_, result) = setup_test_context(vec!["x".to_string()], match_expr);
-
-        // Should succeed
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_duplicate_pattern_bindings() {
-        // Create a pattern match with duplicate bindings
-        let scrutinee = Expr {
-            kind: ExprKind::Ref("x".to_string()),
-            metadata: unknown_span(5, 6),
-        };
-
-        // Create a pattern with duplicate bindings
-        let pat_span = unknown_span(10, 15);
-        let inner_pattern = Pattern {
-            kind: PatternKind::Bind(
-                "y".to_string(),
-                Box::new(Pattern {
-                    kind: PatternKind::Wildcard,
-                    metadata: pat_span.clone(),
-                }),
+        let match_expr = Expr::new_unknown(
+            ExprKind::PatternMatch(
+                Arc::new(Expr::new_unknown(
+                    ExprKind::Ref("x".to_string()),
+                    test_span(5, 6),
+                )),
+                vec![MatchArm {
+                    pattern: Pattern::new_unknown(
+                        PatternKind::Bind(
+                            "y".to_string(),
+                            Box::new(Pattern::new_unknown(
+                                PatternKind::Bind(
+                                    "y".to_string(),
+                                    Box::new(Pattern::new_unknown(
+                                        PatternKind::Wildcard,
+                                        test_span(10, 15),
+                                    )),
+                                ),
+                                test_span(10, 15),
+                            )),
+                        ),
+                        test_span(10, 15),
+                    ),
+                    expr: Arc::new(Expr::new_unknown(
+                        ExprKind::Ref("y".to_string()),
+                        test_span(20, 21),
+                    )),
+                }],
             ),
-            metadata: pat_span.clone(),
-        };
-
-        let outer_pattern = Pattern {
-            kind: PatternKind::Bind(
-                "y".to_string(), // Same name as inner binding
-                Box::new(inner_pattern),
-            ),
-            metadata: pat_span,
-        };
-
-        // Match arm body references the bound variable
-        let arm_body = Expr {
-            kind: ExprKind::Ref("y".to_string()),
-            metadata: unknown_span(20, 21),
-        };
-
-        // Create match arms
-        let arms = vec![MatchArm {
-            pattern: outer_pattern,
-            expr: Arc::new(arm_body),
-        }];
-
-        // Create pattern match expression
-        let match_expr = Expr {
-            kind: ExprKind::PatternMatch(Arc::new(scrutinee), arms),
-            metadata: unknown_span(1, 25),
-        };
+            test_span(1, 25),
+        );
 
         let (_, result) = setup_test_context(vec!["x".to_string()], match_expr);
+        assert!(
+            matches!(result, Err(SemanticErrorKind::DuplicateIdentifier { name, .. }) if name == "y")
+        );
+    }
 
-        // Should fail with DuplicateIdentifier
-        assert!(matches!(result,
-            Err(SemanticErrorKind::DuplicateIdentifier { name, .. }) if name == "y"
-        ));
+    #[test]
+    fn test_block_scope_shadowing() {
+        let x_var = "x".to_string();
+
+        // Create a simple let expression with a block that shadows x
+        let test_expr = Expr::new_unknown(
+            ExprKind::Let(
+                x_var.clone(),
+                Arc::new(Expr::new_unknown(
+                    ExprKind::CoreVal(dummy_value(test_span(1, 2))),
+                    test_span(1, 2),
+                )),
+                Arc::new(Expr::new_unknown(
+                    ExprKind::NewScope(Arc::new(Expr::new_unknown(
+                        ExprKind::Let(
+                            x_var.clone(),
+                            Arc::new(Expr::new_unknown(
+                                ExprKind::CoreVal(dummy_value(test_span(3, 4))),
+                                test_span(3, 4),
+                            )),
+                            Arc::new(Expr::new_unknown(ExprKind::Ref(x_var), test_span(5, 6))),
+                        ),
+                        test_span(2, 7),
+                    ))),
+                    test_span(1, 8),
+                )),
+            ),
+            test_span(0, 9),
+        );
+
+        let (_, result) = setup_test_context(vec![], test_expr);
+        assert!(result.is_ok());
     }
 }

--- a/optd-dsl/src/engine/eval/expr.rs
+++ b/optd-dsl/src/engine/eval/expr.rs
@@ -97,6 +97,31 @@ where
         .await
 }
 
+/// Evaluates a new scope expression.
+///
+/// Creates a new context, pushes a new scope onto it, and evaluates the expression in that
+/// context.
+///
+/// # Parameters
+/// * `expr` - The expression to evaluate.
+/// * `engine` - The evaluation engine.
+/// * `k` - The continuation to receive evaluation results.
+pub(crate) async fn evaluate_new_scope<O>(
+    expr: Arc<Expr>,
+    engine: Engine,
+    k: Continuation<Value, EngineResponse<O>>,
+) -> EngineResponse<O>
+where
+    O: Send + 'static,
+{
+    let mut new_ctx = engine.context.clone();
+    new_ctx.push_scope();
+    engine
+        .with_new_context(new_ctx)
+        .evaluate(expr.clone(), k)
+        .await
+}
+
 /// Evaluates a binary expression.
 ///
 /// Evaluates both operands, then applies the binary operation, passing the result to the
@@ -806,6 +831,61 @@ mod tests {
                 assert_eq!(*value, 15); // 10 + 5 = 15
             }
             _ => panic!("Expected integer value"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_new_scope_and_shadowing() {
+        let harness = TestHarness::new();
+        let mut ctx = Context::default();
+
+        // Bind a variable in the outer scope
+        ctx.bind("x".to_string(), lit_val(int(10)));
+        let engine = Engine::new(ctx);
+
+        // Create a test expression that:
+        // 1. Uses NewScope to create a nested scope
+        // 2. Inside the scope, shadows x with a new value
+        // 3. After leaving the scope, uses x which should have its original value
+        let test_expr = Arc::new(Expr::new(Let(
+            "inner_value".to_string(),
+            Arc::new(Expr::new(NewScope(Arc::new(Expr::new(Let(
+                "x".to_string(), // Shadow x in new scope
+                lit_expr(int(20)),
+                ref_expr("x"), // Return the shadowed value
+            )))))),
+            // Create a tuple with both the inner value and the outer value of x
+            Arc::new(Expr::new(CoreExpr(CoreData::Tuple(vec![
+                ref_expr("inner_value"), // Value from inner scope
+                ref_expr("x"),           // Value from outer scope after leaving inner scope
+            ])))),
+        )));
+
+        let results = evaluate_and_collect(test_expr, engine, harness).await;
+
+        // Check results - should be a tuple (20, 10)
+        assert_eq!(results.len(), 1);
+        match &results[0].data {
+            CoreData::Tuple(elements) => {
+                assert_eq!(elements.len(), 2);
+
+                // First element should be from shadowed variable in inner scope
+                match &elements[0].data {
+                    CoreData::Literal(Literal::Int64(value)) => {
+                        assert_eq!(*value, 20);
+                    }
+                    _ => panic!("Expected integer value"),
+                }
+
+                // Second element should be from outer scope after leaving inner scope
+                match &elements[1].data {
+                    CoreData::Literal(Literal::Int64(value)) => {
+                        assert_eq!(*value, 10);
+                    }
+                    _ => panic!("Expected integer value"),
+                }
+            }
+            _ => panic!("Expected tuple result"),
         }
     }
 

--- a/optd-dsl/src/engine/mod.rs
+++ b/optd-dsl/src/engine/mod.rs
@@ -87,6 +87,13 @@ impl Engine {
                     )
                     .await
                 }
+                NewScope(expr) => {
+                    let mut new_ctx = self.context.clone();
+                    new_ctx.push_scope();
+                    self.with_new_context(new_ctx)
+                        .evaluate(expr.clone(), k)
+                        .await
+                }
                 Let(ident, assignee, after) => {
                     evaluate_let_binding(ident.clone(), assignee.clone(), after.clone(), self, k)
                         .await

--- a/optd-dsl/src/engine/mod.rs
+++ b/optd-dsl/src/engine/mod.rs
@@ -2,10 +2,9 @@ use crate::analyzer::{
     context::Context,
     hir::{Expr, ExprKind, Goal, GroupId, Value},
 };
-use ExprKind::*;
 use eval::expr::{
     evaluate_binary_expr, evaluate_call, evaluate_if_then_else, evaluate_let_binding,
-    evaluate_reference, evaluate_unary_expr,
+    evaluate_new_scope, evaluate_reference, evaluate_unary_expr,
 };
 use eval::r#match::evaluate_pattern_match;
 use eval::{core::evaluate_core_expr, expr::evaluate_map};
@@ -72,6 +71,8 @@ impl Engine {
     where
         O: Send + 'static,
     {
+        use ExprKind::*;
+
         Box::pin(async move {
             match &expr.as_ref().kind {
                 PatternMatch(sub_expr, match_arms) => {
@@ -87,13 +88,7 @@ impl Engine {
                     )
                     .await
                 }
-                NewScope(expr) => {
-                    let mut new_ctx = self.context.clone();
-                    new_ctx.push_scope();
-                    self.with_new_context(new_ctx)
-                        .evaluate(expr.clone(), k)
-                        .await
-                }
+                NewScope(expr) => evaluate_new_scope(expr.clone(), self, k).await,
                 Let(ident, assignee, after) => {
                     evaluate_let_binding(ident.clone(), assignee.clone(), after.clone(), self, k)
                         .await
@@ -152,6 +147,8 @@ impl Engine {
     /// # Returns
     /// A call expression representing the rule invocation
     fn create_rule_call(&self, rule_name: &str, args: Vec<Value>) -> Arc<Expr> {
+        use ExprKind::*;
+
         let rule_name_expr = Expr::new(Ref(rule_name.to_string())).into();
         let arg_exprs = args
             .into_iter()

--- a/optd-dsl/src/parser/ast.rs
+++ b/optd-dsl/src/parser/ast.rs
@@ -87,6 +87,8 @@ pub enum Expr {
     PatternMatch(Spanned<Expr>, Vec<Spanned<MatchArm>>),
     /// Conditional expression (if-then-else)
     IfThenElse(Spanned<Expr>, Spanned<Expr>, Spanned<Expr>),
+    /// Expression block enclosed in braces { }
+    Block(Spanned<Expr>),
 
     // Bindings and constructors
     /// Variable binding (let expressions)

--- a/optd-dsl/src/parser/expr.rs
+++ b/optd-dsl/src/parser/expr.rs
@@ -167,6 +167,8 @@ pub fn expr_parser() -> impl Parser<Token, Spanned<Expr>, Error = Simple<Token, 
         let brace_expr = just(Token::LBrace)
             .ignore_then(expr.clone())
             .then_ignore(just(Token::RBrace))
+            .map(Expr::Block)
+            .map_with_span(Spanned::new)
             .boxed();
 
         let atom = choice((
@@ -901,12 +903,16 @@ mod tests {
                 }
 
                 // Test then branch with let expression
-                if let Expr::Let(name, value, body) = &*then_branch.value {
-                    assert_eq!(*name.value.name.value, "x");
-                    assert_expr_eq(&value.value, &Expr::Literal(Literal::Int64(42)));
-                    assert_expr_eq(&body.value, &Expr::Ref("x".to_string()));
+                if let Expr::Block(body) = &*then_branch.value {
+                    if let Expr::Let(name, value, body) = &*body.value {
+                        assert_eq!(*name.value.name.value, "x");
+                        assert_expr_eq(&value.value, &Expr::Literal(Literal::Int64(42)));
+                        assert_expr_eq(&body.value, &Expr::Ref("x".to_string()));
+                    } else {
+                        panic!("Expected let expression in then branch");
+                    }
                 } else {
-                    panic!("Expected let expression in then branch");
+                    panic!("Expected block expression in then branch");
                 }
 
                 // Test else branch with fail expression


### PR DESCRIPTION
## Problem

Previously, a new block `{ .. }` did not create a new scope where shadowing may happen. This small PR fixes this issue (#58) by adding the feature, hence making the DSL a bit more ergonomic.

## Summary of changes

Adapted the parser, HIR, engine, and analyzer accordingly.
Also refactored the test of `scope_check.rs`, as those were a bit hard to follow.