### PR TITLE
(feat) Finalize Semantic Analyisis & Add Type Annotations

### DIFF
--- a/optd-dsl/src/analyzer/error.rs
+++ b/optd-dsl/src/analyzer/error.rs
@@ -57,6 +57,11 @@ pub enum AnalyzerErrorKind {
         span: Span,
     },
 
+    UnconstructibleType {
+        name: String,
+        span: Span,
+    },
+
     MissingCoreType {
         name: String,
         src_path: String,
@@ -71,6 +76,13 @@ pub enum AnalyzerErrorKind {
         parent_span: Span,
         child_name: String,
         child_span: Span,
+    },
+
+    FieldNumberMismatch {
+        name: String,
+        span: Span,
+        expected: usize,
+        found: usize,
     },
 }
 
@@ -128,6 +140,14 @@ impl AnalyzerErrorKind {
         .into()
     }
 
+    pub fn new_unconstructible_type(name: &str, span: &Span) -> Box<Self> {
+        Self::UnconstructibleType {
+            name: name.to_string(),
+            span: span.clone(),
+        }
+        .into()
+    }
+
     pub fn new_missing_core_type(name: &str, src_path: &str) -> Box<Self> {
         Self::MissingCoreType {
             name: name.to_string(),
@@ -151,6 +171,21 @@ impl AnalyzerErrorKind {
             parent_span: parent_span.clone(),
             child_name: child_name.to_string(),
             child_span: child_span.clone(),
+        }
+        .into()
+    }
+
+    pub fn new_field_number_mismatch(
+        name: &str,
+        span: &Span,
+        expected: usize,
+        found: usize,
+    ) -> Box<Self> {
+        Self::FieldNumberMismatch {
+            name: name.to_string(),
+            span: span.clone(),
+            expected,
+            found,
         }
         .into()
     }
@@ -208,6 +243,12 @@ impl Diagnose for Box<AnalyzerError> {
                 "Undefined type reference",
                 "Make sure the type is declared before use",
             ),
+            UnconstructibleType { name, span } => self.build_single_span_report(
+                span,
+                &format!("Unconstructible type: '{}'", name),
+                "Type cannot be constructed, or does not exist",
+                "Only defined leaf types can be constructed",
+            ),
             MissingCoreType { name, src_path } => {
                 self.build_missing_core_type_report(name, src_path)
             }
@@ -230,6 +271,17 @@ impl Diagnose for Box<AnalyzerError> {
                 "Parent type defined here",
                 "Check the inheritance hierarchy and ensure that the parent type is valid",
             ),
+            FieldNumberMismatch {
+                name,
+                span,
+                expected,
+                found,
+            } => self.build_single_span_report(
+                span,
+                &format!("Field number mismatch in: '{}'", name),
+                &format!("Expected {} fields, but found {}", expected, found),
+                "Check the number of fields in the type definition",
+            ),
         }
     }
 
@@ -243,9 +295,11 @@ impl Diagnose for Box<AnalyzerError> {
             UndefinedReference { span, .. } => span,
             CyclicType { path } => &path[0].span,
             UndefinedType { span, .. } => span,
+            UnconstructibleType { span, .. } => span,
             MissingCoreType { src_path, .. } => &Span::new(src_path.to_string(), 0..0),
             InvalidType { span, .. } => span,
             InvalidInheritance { child_span, .. } => child_span,
+            FieldNumberMismatch { span, .. } => span,
         };
 
         (span.src_file.clone(), Source::from(self.src_code.clone()))

--- a/optd-dsl/src/analyzer/error.rs
+++ b/optd-dsl/src/analyzer/error.rs
@@ -413,12 +413,15 @@ impl AnalyzerError {
 
         Report::build(ReportKind::Error, span.clone())
             .with_message(format!("Missing required core type: '{}'", name))
-            .with_label(
-                Label::new(span.clone())
-                    .with_color(Color::Red),
-            )
-            .with_help(format!("Add a definition for the '{}' type in your module", name))
-            .with_note(format!("Core types must be defined for the language to function correctly. '{}' is a fundamental type needed by the compiler.", name))
+            .with_label(Label::new(span.clone()).with_color(Color::Red))
+            .with_help(format!(
+                "Add a definition for the '{}' type in your module",
+                name
+            ))
+            .with_note(format!(
+                "'{}' is a fundamental type needed by the compiler",
+                name
+            ))
             .finish()
     }
 }

--- a/optd-dsl/src/analyzer/from_ast/converter.rs
+++ b/optd-dsl/src/analyzer/from_ast/converter.rs
@@ -50,11 +50,11 @@ impl ASTConverter {
         // for invalid type annotations & constructions.
         for item in &module.items {
             if let Item::Function(spanned_fn) = item {
-                self.process_function(spanned_fn)?;
+                self.register_function(spanned_fn)?;
             }
         }
 
-        // Push the context scope of the module, as we have processed all functionss.
+        // Push the context scope of the module, as we have processed all functions.
         self.context.push_scope();
 
         Ok((
@@ -66,10 +66,10 @@ impl ASTConverter {
         ))
     }
 
-    /// Processes a function AST node and adds it to the context.
+    /// Registers a function AST node and adds it to the context.
     ///
     /// Handles function parameters, return type, and body conversion.
-    pub(super) fn process_function(
+    pub(super) fn register_function(
         &mut self,
         spanned_fn: &Spanned<Function>,
     ) -> Result<(), Box<AnalyzerErrorKind>> {
@@ -164,7 +164,7 @@ impl ASTConverter {
                             self.convert_type(&field.ty, generics)?,
                         ))
                     })
-                    .collect::<Result<Vec<_>, Box<AnalyzerErrorKind>>>()?,
+                    .collect::<Result<Vec<_>, Box<_>>>()?,
             );
         }
 

--- a/optd-dsl/src/analyzer/from_ast/expr.rs
+++ b/optd-dsl/src/analyzer/from_ast/expr.rs
@@ -32,7 +32,15 @@ impl ASTConverter {
 
         let kind = match &*spanned_expr.value {
             AstExpr::Error => panic!("AST should no longer contain errors"),
-            AstExpr::Literal(lit) => self.convert_literal(lit, &span),
+            AstExpr::Literal(lit) => {
+                let (hir_lit, hir_ty) = self.convert_literal(lit);
+                ty = hir_ty;
+                CoreVal(Value::new_with(
+                    CoreData::Literal(hir_lit),
+                    ty.clone(),
+                    span.clone(),
+                ))
+            }
             AstExpr::Ref(ident) => self.convert_ref(ident),
             AstExpr::Binary(left, op, right) => {
                 self.convert_binary(left, op, right, &span, generics)?
@@ -60,7 +68,7 @@ impl ASTConverter {
                 // We extract the potential type annotations.
                 let params = params
                     .iter()
-                    .map(|field| -> Result<_, _> {
+                    .map(|field| {
                         Ok((
                             (*field.name).clone(),
                             self.convert_type(&field.ty, generics)?,
@@ -73,7 +81,7 @@ impl ASTConverter {
             }
             AstExpr::Postfix(expr, op) => self.convert_postfix(expr, op, generics)?,
             AstExpr::Fail(error_expr) => {
-                ty = Type::Never;
+                ty = Type::Nothing;
                 self.convert_fail(error_expr, generics)?
             }
             AstExpr::None => {
@@ -86,22 +94,18 @@ impl ASTConverter {
         Ok(Expr::new_with(kind, ty, span))
     }
 
-    fn convert_literal(&self, literal: &AstLiteral, span: &Span) -> ExprKind<TypedSpan> {
+    // Slightly different signature so that we can use it in pattern.rs,
+    // and also get the type at the same time.
+    pub(super) fn convert_literal(&self, literal: &AstLiteral) -> (Literal, Type) {
         use Literal::*;
 
-        let (hir_lit, hir_ty) = match literal {
+        match literal {
             AstLiteral::Int64(val) => (Int64(*val), Type::Int64),
             AstLiteral::String(val) => (String(val.clone()), Type::String),
             AstLiteral::Bool(val) => (Bool(*val), Type::Bool),
             AstLiteral::Float64(val) => (Float64(val.0), Type::Float64),
             AstLiteral::Unit => (Unit, Type::Unit),
-        };
-
-        CoreVal(Value::new_with(
-            CoreData::Literal(hir_lit),
-            hir_ty,
-            span.clone(),
-        ))
+        }
     }
 
     fn convert_ref(&self, ident: &Identifier) -> ExprKind<TypedSpan> {

--- a/optd-dsl/src/analyzer/from_ast/expr.rs
+++ b/optd-dsl/src/analyzer/from_ast/expr.rs
@@ -9,7 +9,9 @@ use crate::analyzer::hir::{
     BinOp, CoreData, Expr, ExprKind, FunKind, Identifier, Literal, TypedSpan, UnaryOp, Value,
 };
 use crate::analyzer::types::Type;
-use crate::parser::ast::{self, BinOp as AstBinOp, Expr as AstExpr};
+use crate::parser::ast::{
+    self, BinOp as AstBinOp, Expr as AstExpr, Literal as AstLiteral, PostfixOp,
+};
 use crate::utils::span::{Span, Spanned};
 use ExprKind::*;
 use std::collections::HashSet;
@@ -50,7 +52,10 @@ impl ASTConverter {
             AstExpr::Array(elements) => self.convert_array(elements, generics)?,
             AstExpr::Tuple(elements) => self.convert_tuple(elements, generics)?,
             AstExpr::Map(entries) => self.convert_map(entries, generics)?,
-            AstExpr::Constructor(name, args) => self.convert_constructor(name, args, generics)?,
+            AstExpr::Constructor(name, args) => {
+                ty = Type::Adt(*name.value.clone());
+                self.convert_constructor(name, args, &span, generics)?
+            }
             AstExpr::Closure(params, body) => {
                 // We extract the potential type annotations.
                 let params = params
@@ -61,30 +66,42 @@ impl ASTConverter {
                             self.convert_type(&field.ty, generics)?,
                         ))
                     })
-                    .collect::<Result<Vec<_>, Box<AnalyzerErrorKind>>>()?;
+                    .collect::<Result<Vec<_>, Box<_>>>()?;
 
                 ty = Self::create_function_type(&params, &Type::Unknown);
                 self.convert_closure(&params, body, generics)?
             }
             AstExpr::Postfix(expr, op) => self.convert_postfix(expr, op, generics)?,
-            AstExpr::Fail(error_expr) => self.convert_fail(error_expr, generics)?,
-            AstExpr::None => CoreVal(Value::new_unknown(CoreData::None, span.clone())),
+            AstExpr::Fail(error_expr) => {
+                ty = Type::Never;
+                self.convert_fail(error_expr, generics)?
+            }
+            AstExpr::None => {
+                ty = Type::None;
+                CoreVal(Value::new_unknown(CoreData::None, span.clone()))
+            }
             AstExpr::Block(block) => self.convert_block(block, generics)?,
         };
 
         Ok(Expr::new_with(kind, ty, span))
     }
 
-    fn convert_literal(&self, literal: &ast::Literal, span: &Span) -> ExprKind<TypedSpan> {
-        let hir_lit = match literal {
-            ast::Literal::Int64(val) => Literal::Int64(*val),
-            ast::Literal::String(val) => Literal::String(val.clone()),
-            ast::Literal::Bool(val) => Literal::Bool(*val),
-            ast::Literal::Float64(val) => Literal::Float64(val.0),
-            ast::Literal::Unit => Literal::Unit,
+    fn convert_literal(&self, literal: &AstLiteral, span: &Span) -> ExprKind<TypedSpan> {
+        use Literal::*;
+
+        let (hir_lit, hir_ty) = match literal {
+            AstLiteral::Int64(val) => (Int64(*val), Type::Int64),
+            AstLiteral::String(val) => (String(val.clone()), Type::String),
+            AstLiteral::Bool(val) => (Bool(*val), Type::Bool),
+            AstLiteral::Float64(val) => (Float64(val.0), Type::Float64),
+            AstLiteral::Unit => (Unit, Type::Unit),
         };
 
-        CoreVal(Value::new_unknown(CoreData::Literal(hir_lit), span.clone()))
+        CoreVal(Value::new_with(
+            CoreData::Literal(hir_lit),
+            hir_ty,
+            span.clone(),
+        ))
     }
 
     fn convert_ref(&self, ident: &Identifier) -> ExprKind<TypedSpan> {
@@ -286,22 +303,47 @@ impl ASTConverter {
         Ok(Map(hir_entries))
     }
 
+    pub(super) fn validate_constructor(
+        &self,
+        name: &Spanned<Identifier>,
+        span: &Span,
+        actual_size: usize,
+    ) -> Result<(), Box<AnalyzerErrorKind>> {
+        // Lookup the product fields and validate they exist.
+        let product_fields = match self.type_registry.product_fields.get(&*name.value) {
+            Some(fields) => fields,
+            None => {
+                return Err(AnalyzerErrorKind::new_unconstructible_type(
+                    &name.value,
+                    &name.span,
+                ));
+            }
+        };
+
+        // Check if the number of arguments matches the expected field count.
+        let expected_size = product_fields.len();
+        if expected_size != actual_size {
+            return Err(AnalyzerErrorKind::new_field_number_mismatch(
+                &name.value,
+                span,
+                expected_size,
+                actual_size,
+            ));
+        }
+
+        Ok(())
+    }
+
     fn convert_constructor(
         &self,
         name: &Spanned<Identifier>,
         args: &[Spanned<AstExpr>],
+        span: &Span,
         generics: &HashSet<Identifier>,
     ) -> Result<ExprKind<TypedSpan>, Box<AnalyzerErrorKind>> {
+        self.validate_constructor(name, span, args.len())?;
+
         let hir_args = self.convert_expr_list(args, generics)?;
-
-        // Check if the corresponding type exists.
-        if !self.type_registry.subtypes.contains_key(&*name.value) {
-            return Err(AnalyzerErrorKind::new_undefined_type(
-                &name.value,
-                &name.span,
-            ));
-        }
-
         Ok(CoreExpr(CoreData::Struct(*name.value.clone(), hir_args)))
     }
 
@@ -323,23 +365,23 @@ impl ASTConverter {
     fn convert_postfix(
         &self,
         expr: &Spanned<AstExpr>,
-        op: &ast::PostfixOp,
+        op: &PostfixOp,
         generics: &HashSet<Identifier>,
     ) -> Result<ExprKind<TypedSpan>, Box<AnalyzerErrorKind>> {
         let hir_expr = self.convert_expr(expr, generics)?;
 
         match op {
-            ast::PostfixOp::Call(args) => {
+            PostfixOp::Call(args) => {
                 let hir_args = self.convert_expr_list(args, generics)?;
                 Ok(Call(hir_expr.into(), hir_args))
             }
-            ast::PostfixOp::Field(field_name) => {
+            PostfixOp::Field(field_name) => {
                 // Wait until after type inference to transform this
                 // into a `Call` operation.
                 Ok(FieldAccess(hir_expr.into(), (*field_name.value).clone()))
             }
             // Desugar method call (obj.method(args)) into function call (method(obj, args)).
-            ast::PostfixOp::Method(method_name, args) => {
+            PostfixOp::Method(method_name, args) => {
                 let all_args = std::iter::once(hir_expr.into())
                     .chain(self.convert_expr_list(args, generics)?)
                     .collect();
@@ -379,7 +421,7 @@ impl ASTConverter {
 mod expr_tests {
     use super::*;
     use crate::analyzer::hir::{BinOp, ExprKind, Literal, PatternKind, UnaryOp};
-    use crate::parser::ast;
+    use crate::parser::ast::{self, Field};
     use crate::utils::span::{Span, Spanned};
     use std::collections::HashSet;
 
@@ -392,19 +434,12 @@ mod expr_tests {
         Spanned::new(value, create_test_span())
     }
 
-    fn create_test_adt(name: &str) -> ast::Adt {
-        ast::Adt::Product {
-            name: spanned(name.to_string()),
-            fields: vec![],
-        }
-    }
-
     #[test]
     fn test_convert_literal() {
         let converter = ASTConverter::default();
 
         // Test integer literal
-        let int_lit = spanned(AstExpr::Literal(ast::Literal::Int64(42)));
+        let int_lit = spanned(AstExpr::Literal(AstLiteral::Int64(42)));
         let result = converter
             .convert_expr(&int_lit, &HashSet::new())
             .expect("Integer literal conversion should succeed");
@@ -418,7 +453,7 @@ mod expr_tests {
         }
 
         // Test string literal
-        let str_lit = spanned(AstExpr::Literal(ast::Literal::String("hello".to_string())));
+        let str_lit = spanned(AstExpr::Literal(AstLiteral::String("hello".to_string())));
         let result = converter
             .convert_expr(&str_lit, &HashSet::new())
             .expect("String literal conversion should succeed");
@@ -432,7 +467,7 @@ mod expr_tests {
         }
 
         // Test boolean literal
-        let bool_lit = spanned(AstExpr::Literal(ast::Literal::Bool(true)));
+        let bool_lit = spanned(AstExpr::Literal(AstLiteral::Bool(true)));
         let result = converter
             .convert_expr(&bool_lit, &HashSet::new())
             .expect("Boolean literal conversion should succeed");
@@ -447,7 +482,7 @@ mod expr_tests {
 
         // Test float literal
         let float_val = std::f64::consts::PI;
-        let float_lit = spanned(ast::Expr::Literal(ast::Literal::Float64(
+        let float_lit = spanned(ast::Expr::Literal(AstLiteral::Float64(
             ordered_float::OrderedFloat(float_val),
         )));
         let result = converter
@@ -463,7 +498,7 @@ mod expr_tests {
         }
 
         // Test unit literal
-        let unit_lit = spanned(AstExpr::Literal(ast::Literal::Unit));
+        let unit_lit = spanned(AstExpr::Literal(AstLiteral::Unit));
         let result = converter
             .convert_expr(&unit_lit, &HashSet::new())
             .expect("Unit literal conversion should succeed");
@@ -498,8 +533,8 @@ mod expr_tests {
 
         // Helper to create binary operator tests
         let test_binary_op = |op: AstBinOp, expected_op: BinOp| {
-            let left = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-            let right = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+            let left = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+            let right = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
             let bin_expr = spanned(AstExpr::Binary(left, op, right));
 
             let result = converter
@@ -530,8 +565,8 @@ mod expr_tests {
         let converter = ASTConverter::default();
 
         // Test != (not equal) desugaring to !(left == right)
-        let left = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let right = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+        let left = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let right = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
         let neq_expr = spanned(AstExpr::Binary(left, AstBinOp::Neq, right));
 
         let result = converter
@@ -544,8 +579,8 @@ mod expr_tests {
         }
 
         // Test > (greater than) desugaring to right < left (swapped operands)
-        let left = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let right = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+        let left = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let right = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
         let gt_expr = spanned(AstExpr::Binary(left, AstBinOp::Gt, right));
 
         let result = converter
@@ -569,8 +604,8 @@ mod expr_tests {
         }
 
         // Test >= (greater than or equal) desugaring to !(left < right)
-        let left = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let right = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+        let left = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let right = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
         let ge_expr = spanned(AstExpr::Binary(left, AstBinOp::Ge, right));
 
         let result = converter
@@ -583,8 +618,8 @@ mod expr_tests {
         }
 
         // Test <= (less than or equal) desugaring to left < right || left == right
-        let left = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let right = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+        let left = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let right = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
         let le_expr = spanned(AstExpr::Binary(left, AstBinOp::Le, right));
 
         let result = converter
@@ -602,7 +637,7 @@ mod expr_tests {
         let converter = ASTConverter::default();
 
         // Test negation
-        let operand = spanned(AstExpr::Literal(ast::Literal::Int64(42)));
+        let operand = spanned(AstExpr::Literal(AstLiteral::Int64(42)));
         let neg_expr = spanned(AstExpr::Unary(ast::UnaryOp::Neg, operand));
 
         let result = converter
@@ -615,7 +650,7 @@ mod expr_tests {
         }
 
         // Test logical not
-        let operand = spanned(AstExpr::Literal(ast::Literal::Bool(true)));
+        let operand = spanned(AstExpr::Literal(AstLiteral::Bool(true)));
         let not_expr = spanned(AstExpr::Unary(ast::UnaryOp::Not, operand));
 
         let result = converter
@@ -638,7 +673,7 @@ mod expr_tests {
             ty: spanned(ast::Type::Int64),
         });
 
-        let init = spanned(AstExpr::Literal(ast::Literal::Int64(42)));
+        let init = spanned(AstExpr::Literal(AstLiteral::Int64(42)));
         let body = spanned(AstExpr::Ref(var_name.clone()));
 
         let let_expr = spanned(AstExpr::Let(field, init, body));
@@ -656,9 +691,9 @@ mod expr_tests {
     fn test_convert_if_then_else() {
         let converter = ASTConverter::default();
 
-        let condition = spanned(AstExpr::Literal(ast::Literal::Bool(true)));
-        let then_branch = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let else_branch = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+        let condition = spanned(AstExpr::Literal(AstLiteral::Bool(true)));
+        let then_branch = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let else_branch = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
 
         let if_expr = spanned(AstExpr::IfThenElse(condition, then_branch, else_branch));
         let result = converter
@@ -675,9 +710,9 @@ mod expr_tests {
     fn test_convert_array() {
         let converter = ASTConverter::default();
 
-        let elem1 = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let elem2 = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
-        let elem3 = spanned(AstExpr::Literal(ast::Literal::Int64(3)));
+        let elem1 = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let elem2 = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
+        let elem3 = spanned(AstExpr::Literal(AstLiteral::Int64(3)));
 
         let array_expr = spanned(AstExpr::Array(vec![elem1, elem2, elem3]));
         let result = converter
@@ -696,9 +731,9 @@ mod expr_tests {
     fn test_convert_tuple() {
         let converter = ASTConverter::default();
 
-        let elem1 = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let elem2 = spanned(AstExpr::Literal(ast::Literal::Bool(true)));
-        let elem3 = spanned(AstExpr::Literal(ast::Literal::String("test".to_string())));
+        let elem1 = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let elem2 = spanned(AstExpr::Literal(AstLiteral::Bool(true)));
+        let elem3 = spanned(AstExpr::Literal(AstLiteral::String("test".to_string())));
 
         let tuple_expr = spanned(AstExpr::Tuple(vec![elem1, elem2, elem3]));
         let result = converter
@@ -717,11 +752,11 @@ mod expr_tests {
     fn test_convert_map() {
         let converter = ASTConverter::default();
 
-        let key1 = spanned(AstExpr::Literal(ast::Literal::String("key1".to_string())));
-        let val1 = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
+        let key1 = spanned(AstExpr::Literal(AstLiteral::String("key1".to_string())));
+        let val1 = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
 
-        let key2 = spanned(AstExpr::Literal(ast::Literal::String("key2".to_string())));
-        let val2 = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+        let key2 = spanned(AstExpr::Literal(AstLiteral::String("key2".to_string())));
+        let val2 = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
 
         let map_expr = spanned(AstExpr::Map(vec![(key1, val1), (key2, val2)]));
         let result = converter
@@ -740,15 +775,28 @@ mod expr_tests {
     fn test_convert_constructor() {
         let mut converter = ASTConverter::default();
 
-        // Register "Point" type in the registry
-        let point_adt = create_test_adt("Point");
+        // Register "Point" type in the registry with 2 fields
+        let point_adt = ast::Adt::Product {
+            name: spanned("Point".to_string()),
+            fields: vec![
+                spanned(Field {
+                    name: spanned("x".to_string()),
+                    ty: spanned(ast::Type::Int64),
+                }),
+                spanned(Field {
+                    name: spanned("y".to_string()),
+                    ty: spanned(ast::Type::String),
+                }),
+            ],
+        };
+
         converter
             .type_registry
             .register_adt(&point_adt)
             .expect("Failed to register Point type");
 
-        let arg1 = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let arg2 = spanned(AstExpr::Literal(ast::Literal::String("test".to_string())));
+        let arg1 = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let arg2 = spanned(AstExpr::Literal(AstLiteral::String("test".to_string())));
 
         let constructor_expr = spanned(AstExpr::Constructor(
             spanned("Point".to_string()),
@@ -784,19 +832,33 @@ mod expr_tests {
         let mut converter = ASTConverter::default();
 
         // Register multiple types for testing nested constructors
-        let types = ["Container", "Item", "Property"];
-        for ty in &types {
-            let adt = create_test_adt(ty);
+        let types = [("Container", 1), ("Item", 1), ("Property", 1)];
+
+        for (name, field_count) in &types {
+            let fields = (0..*field_count)
+                .map(|i| {
+                    spanned(Field {
+                        name: spanned(format!("field{}", i)),
+                        ty: spanned(ast::Type::Int64),
+                    })
+                })
+                .collect();
+
+            let adt = ast::Adt::Product {
+                name: spanned(name.to_string()),
+                fields,
+            };
+
             converter
                 .type_registry
                 .register_adt(&adt)
-                .unwrap_or_else(|_| panic!("Failed to register {} type", ty));
+                .unwrap_or_else(|_| panic!("Failed to register {} type", name));
         }
 
         // Create nested constructor expressions
         let property = spanned(AstExpr::Constructor(
             spanned("Property".to_string()),
-            vec![spanned(AstExpr::Literal(ast::Literal::String(
+            vec![spanned(AstExpr::Literal(AstLiteral::String(
                 "color".to_string(),
             )))],
         ));
@@ -821,7 +883,7 @@ mod expr_tests {
         // Test with one invalid type in the nested structure
         let invalid_property = spanned(AstExpr::Constructor(
             spanned("InvalidType".to_string()),
-            vec![spanned(AstExpr::Literal(ast::Literal::String(
+            vec![spanned(AstExpr::Literal(AstLiteral::String(
                 "color".to_string(),
             )))],
         ));
@@ -848,20 +910,34 @@ mod expr_tests {
     fn test_constructor_in_complex_expressions() {
         let mut converter = ASTConverter::default();
 
-        // Register necessary types
-        let types = ["User", "Address", "Order"];
-        for ty in &types {
-            let adt = create_test_adt(ty);
+        // Register necessary types with appropriate field counts
+        let types = [("User", 1), ("Address", 1), ("Order", 1)];
+
+        for (name, field_count) in &types {
+            let fields = (0..*field_count)
+                .map(|i| {
+                    spanned(Field {
+                        name: spanned(format!("field{}", i)),
+                        ty: spanned(ast::Type::Int64),
+                    })
+                })
+                .collect();
+
+            let adt = ast::Adt::Product {
+                name: spanned(name.to_string()),
+                fields,
+            };
+
             converter
                 .type_registry
                 .register_adt(&adt)
-                .unwrap_or_else(|_| panic!("Failed to register {} type", ty));
+                .unwrap_or_else(|_| panic!("Failed to register {} type", name));
         }
 
         // Create a constructor inside a let expression
         let address_constructor = spanned(AstExpr::Constructor(
             spanned("Address".to_string()),
-            vec![spanned(AstExpr::Literal(ast::Literal::String(
+            vec![spanned(AstExpr::Literal(AstLiteral::String(
                 "123 Main St".to_string(),
             )))],
         ));
@@ -885,7 +961,7 @@ mod expr_tests {
         // Test with invalid type in constructor inside let
         let invalid_constructor = spanned(AstExpr::Constructor(
             spanned("InvalidType".to_string()),
-            vec![spanned(AstExpr::Literal(ast::Literal::String(
+            vec![spanned(AstExpr::Literal(AstLiteral::String(
                 "123 Main St".to_string(),
             )))],
         ));
@@ -902,6 +978,71 @@ mod expr_tests {
         assert!(
             result.is_err(),
             "Let with invalid constructor type should fail"
+        );
+    }
+
+    #[test]
+    fn test_constructor_field_count_validation() {
+        let mut converter = ASTConverter::default();
+
+        // Register a Point type with 2 fields
+        let point_adt = ast::Adt::Product {
+            name: spanned("Point".to_string()),
+            fields: vec![
+                spanned(Field {
+                    name: spanned("x".to_string()),
+                    ty: spanned(ast::Type::Int64),
+                }),
+                spanned(Field {
+                    name: spanned("y".to_string()),
+                    ty: spanned(ast::Type::Int64),
+                }),
+            ],
+        };
+
+        converter
+            .type_registry
+            .register_adt(&point_adt)
+            .expect("Failed to register Point type");
+
+        // Test with correct number of arguments (2)
+        let arg1 = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let arg2 = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
+
+        let correct_constructor = spanned(AstExpr::Constructor(
+            spanned("Point".to_string()),
+            vec![arg1.clone(), arg2.clone()],
+        ));
+
+        let result = converter.convert_expr(&correct_constructor, &HashSet::new());
+        assert!(
+            result.is_ok(),
+            "Constructor with correct field count should succeed"
+        );
+
+        // Test with too few arguments (1 instead of 2)
+        let too_few_args = spanned(AstExpr::Constructor(
+            spanned("Point".to_string()),
+            vec![arg1.clone()],
+        ));
+
+        let result = converter.convert_expr(&too_few_args, &HashSet::new());
+        assert!(
+            result.is_err(),
+            "Constructor with too few arguments should fail"
+        );
+
+        // Test with too many arguments (3 instead of 2)
+        let arg3 = spanned(AstExpr::Literal(AstLiteral::Int64(3)));
+        let too_many_args = spanned(AstExpr::Constructor(
+            spanned("Point".to_string()),
+            vec![arg1, arg2, arg3],
+        ));
+
+        let result = converter.convert_expr(&too_many_args, &HashSet::new());
+        assert!(
+            result.is_err(),
+            "Constructor with too many arguments should fail"
         );
     }
 
@@ -934,8 +1075,8 @@ mod expr_tests {
         let converter = ASTConverter::default();
 
         let func = spanned(AstExpr::Ref("add".to_string()));
-        let arg1 = spanned(AstExpr::Literal(ast::Literal::Int64(1)));
-        let arg2 = spanned(AstExpr::Literal(ast::Literal::Int64(2)));
+        let arg1 = spanned(AstExpr::Literal(AstLiteral::Int64(1)));
+        let arg2 = spanned(AstExpr::Literal(AstLiteral::Int64(2)));
 
         let call_expr = spanned(AstExpr::Postfix(
             func,
@@ -984,7 +1125,7 @@ mod expr_tests {
 
         let obj = spanned(AstExpr::Ref("list".to_string()));
         let method_name = spanned("add".to_string());
-        let arg = spanned(AstExpr::Literal(ast::Literal::Int64(42)));
+        let arg = spanned(AstExpr::Literal(AstLiteral::Int64(42)));
 
         let method_call_expr = spanned(AstExpr::Postfix(
             obj,
@@ -1020,7 +1161,7 @@ mod expr_tests {
     fn test_convert_fail() {
         let converter = ASTConverter::default();
 
-        let error_expr = spanned(AstExpr::Literal(ast::Literal::String("error".to_string())));
+        let error_expr = spanned(AstExpr::Literal(AstLiteral::String("error".to_string())));
         let fail_expr = spanned(AstExpr::Fail(error_expr));
         let result = converter
             .convert_expr(&fail_expr, &HashSet::new())
@@ -1043,7 +1184,19 @@ mod expr_tests {
         let mut converter = ASTConverter::default();
 
         // Register a type for constructor patterns
-        let point_adt = create_test_adt("Point");
+        let point_adt = ast::Adt::Product {
+            name: spanned("Point".to_string()),
+            fields: vec![
+                spanned(Field {
+                    name: spanned("x".to_string()),
+                    ty: spanned(ast::Type::Int64),
+                }),
+                spanned(Field {
+                    name: spanned("y".to_string()),
+                    ty: spanned(ast::Type::Int64),
+                }),
+            ],
+        };
         converter
             .type_registry
             .register_adt(&point_adt)
@@ -1053,8 +1206,8 @@ mod expr_tests {
         let scrutinee = spanned(AstExpr::Ref("value".to_string()));
 
         // Pattern 1: literal pattern
-        let pattern1 = spanned(ast::Pattern::Literal(ast::Literal::Int64(0)));
-        let expr1 = spanned(AstExpr::Literal(ast::Literal::String("zero".to_string())));
+        let pattern1 = spanned(ast::Pattern::Literal(AstLiteral::Int64(0)));
+        let expr1 = spanned(AstExpr::Literal(AstLiteral::String("zero".to_string())));
         let arm1 = spanned(ast::MatchArm {
             pattern: pattern1,
             expr: expr1,
@@ -1102,12 +1255,15 @@ mod expr_tests {
             _ => panic!("Expected PatternMatch expression"),
         }
 
-        // Test pattern match with constructor pattern
+        // Test pattern match with constructor pattern (with correct field count)
         let constructor_pattern = spanned(ast::Pattern::Constructor(
             spanned("Point".to_string()),
-            vec![],
+            vec![
+                spanned(ast::Pattern::Wildcard),
+                spanned(ast::Pattern::Wildcard),
+            ],
         ));
-        let expr3 = spanned(AstExpr::Literal(ast::Literal::String("point".to_string())));
+        let expr3 = spanned(AstExpr::Literal(AstLiteral::String("point".to_string())));
         let arm3 = spanned(ast::MatchArm {
             pattern: constructor_pattern,
             expr: expr3.clone(),
@@ -1123,7 +1279,10 @@ mod expr_tests {
         // Test pattern match with invalid constructor pattern
         let invalid_pattern = spanned(ast::Pattern::Constructor(
             spanned("InvalidType".to_string()),
-            vec![],
+            vec![
+                spanned(ast::Pattern::Wildcard),
+                spanned(ast::Pattern::Wildcard),
+            ],
         ));
         let invalid_arm = spanned(ast::MatchArm {
             pattern: invalid_pattern,
@@ -1143,7 +1302,7 @@ mod expr_tests {
         let converter = ASTConverter::default();
 
         // Create a simple expression inside a block
-        let inner_expr = spanned(AstExpr::Literal(ast::Literal::Int64(42)));
+        let inner_expr = spanned(AstExpr::Literal(AstLiteral::Int64(42)));
         let block_expr = spanned(AstExpr::Block(inner_expr));
 
         let result = converter
@@ -1174,10 +1333,7 @@ mod expr_tests {
         let custom_span = Span::new("test_file.txt".to_string(), 10..20);
 
         // Create a simple expression with that span
-        let expr = Spanned::new(
-            AstExpr::Literal(ast::Literal::Int64(42)),
-            custom_span.clone(),
-        );
+        let expr = Spanned::new(AstExpr::Literal(AstLiteral::Int64(42)), custom_span.clone());
 
         // Convert the expression
         let result = converter

--- a/optd-dsl/src/analyzer/from_ast/pattern.rs
+++ b/optd-dsl/src/analyzer/from_ast/pattern.rs
@@ -6,7 +6,7 @@
 use super::ASTConverter;
 use crate::analyzer::error::AnalyzerErrorKind;
 use crate::analyzer::hir::{Identifier, Literal, MatchArm, Pattern, PatternKind, TypedSpan};
-use crate::parser::ast;
+use crate::parser::ast::{self, Literal as AstLiteral, Pattern as AstPattern};
 use crate::utils::span::Spanned;
 use PatternKind::*;
 use std::collections::HashSet;
@@ -41,54 +41,50 @@ impl ASTConverter {
     /// will be handled in a later phase.
     fn convert_pattern(
         &self,
-        spanned_pattern: &Spanned<ast::Pattern>,
+        spanned_pattern: &Spanned<AstPattern>,
     ) -> Result<Pattern<TypedSpan>, Box<AnalyzerErrorKind>> {
+        use Literal::*;
+
         let span = spanned_pattern.span.clone();
 
         let kind = match &*spanned_pattern.value {
-            ast::Pattern::Error => panic!("AST should no longer contain errors"),
+            AstPattern::Error => panic!("AST should no longer contain errors"),
 
-            ast::Pattern::Bind(name, inner_pattern) => {
+            AstPattern::Bind(name, inner_pattern) => {
                 let hir_inner = self.convert_pattern(inner_pattern)?;
                 Bind((*name.value).clone(), hir_inner.into())
             }
 
-            ast::Pattern::Constructor(name, args) => {
+            AstPattern::Constructor(name, args) => {
+                self.validate_constructor(name, &span, args.len())?;
+
                 let hir_args = args
                     .iter()
                     .map(|arg| self.convert_pattern(arg))
                     .collect::<Result<Vec<_>, _>>()?;
-
-                // Check if the corresponding type exists.
-                if !self.type_registry.subtypes.contains_key(&*name.value) {
-                    return Err(AnalyzerErrorKind::new_undefined_type(
-                        &name.value,
-                        &name.span,
-                    ));
-                }
 
                 // Wait until after type inference to transform this into
                 // an operator if needed.
                 Struct((*name.value).clone(), hir_args)
             }
 
-            ast::Pattern::Literal(lit) => {
+            AstPattern::Literal(lit) => {
                 let hir_lit = match lit {
-                    ast::Literal::Int64(val) => Literal::Int64(*val),
-                    ast::Literal::String(val) => Literal::String(val.clone()),
-                    ast::Literal::Bool(val) => Literal::Bool(*val),
-                    ast::Literal::Float64(val) => Literal::Float64(val.0),
-                    ast::Literal::Unit => Literal::Unit,
+                    AstLiteral::Int64(val) => Int64(*val),
+                    AstLiteral::String(val) => String(val.clone()),
+                    AstLiteral::Bool(val) => Bool(*val),
+                    AstLiteral::Float64(val) => Float64(val.0),
+                    AstLiteral::Unit => Unit,
                 };
 
                 Literal(hir_lit)
             }
 
-            ast::Pattern::Wildcard => Wildcard,
+            AstPattern::Wildcard => Wildcard,
 
-            ast::Pattern::EmptyArray => EmptyArray,
+            AstPattern::EmptyArray => EmptyArray,
 
-            ast::Pattern::ArrayDecomp(head, tail) => {
+            AstPattern::ArrayDecomp(head, tail) => {
                 let hir_head = self.convert_pattern(head)?;
                 let hir_tail = self.convert_pattern(tail)?;
 
@@ -104,7 +100,7 @@ impl ASTConverter {
 mod pattern_tests {
     use crate::analyzer::from_ast::ASTConverter;
     use crate::analyzer::hir::{Literal, PatternKind};
-    use crate::parser::ast;
+    use crate::parser::ast::{self, Field, Literal as AstLiteral, Pattern as AstPattern};
     use crate::utils::span::{Span, Spanned};
     use std::collections::HashSet;
 
@@ -117,17 +113,26 @@ mod pattern_tests {
         Spanned::new(value, create_test_span())
     }
 
-    fn create_match_arm(pattern: ast::Pattern, expr: ast::Expr) -> Spanned<ast::MatchArm> {
+    fn create_match_arm(pattern: AstPattern, expr: ast::Expr) -> Spanned<ast::MatchArm> {
         spanned(ast::MatchArm {
             pattern: spanned(pattern),
             expr: spanned(expr),
         })
     }
 
-    fn create_test_adt(name: &str) -> ast::Adt {
+    fn create_product_adt(name: &str, field_count: usize) -> ast::Adt {
+        let fields = (0..field_count)
+            .map(|i| {
+                spanned(Field {
+                    name: spanned(format!("field{}", i)),
+                    ty: spanned(ast::Type::Int64),
+                })
+            })
+            .collect();
+
         ast::Adt::Product {
             name: spanned(name.to_string()),
-            fields: vec![],
+            fields,
         }
     }
 
@@ -136,24 +141,28 @@ mod pattern_tests {
         let mut converter = ASTConverter::default();
 
         // Register "Point" type for constructor patterns in match arms
-        let point_adt = create_test_adt("Point");
+        // with 2 fields
+        let point_adt = create_product_adt("Point", 2);
         converter
             .type_registry
             .register_adt(&point_adt)
             .expect("Failed to register Point type");
 
         // Create a set of match arms
-        let pattern1 = ast::Pattern::Literal(ast::Literal::Int64(1));
-        let expr1 = ast::Expr::Literal(ast::Literal::String("one".to_string()));
+        let pattern1 = AstPattern::Literal(AstLiteral::Int64(1));
+        let expr1 = ast::Expr::Literal(AstLiteral::String("one".to_string()));
         let arm1 = create_match_arm(pattern1, expr1);
 
-        let pattern2 = ast::Pattern::Wildcard;
-        let expr2 = ast::Expr::Literal(ast::Literal::String("other".to_string()));
+        let pattern2 = AstPattern::Wildcard;
+        let expr2 = ast::Expr::Literal(AstLiteral::String("other".to_string()));
         let arm2 = create_match_arm(pattern2, expr2);
 
-        // Create a constructor pattern
-        let pattern3 = ast::Pattern::Constructor(spanned("Point".to_string()), vec![]);
-        let expr3 = ast::Expr::Literal(ast::Literal::String("point".to_string()));
+        // Create a constructor pattern with the correct number of fields (2)
+        let pattern3 = AstPattern::Constructor(
+            spanned("Point".to_string()),
+            vec![spanned(AstPattern::Wildcard), spanned(AstPattern::Wildcard)],
+        );
+        let expr3 = ast::Expr::Literal(AstLiteral::String("point".to_string()));
         let arm3 = create_match_arm(pattern3, expr3);
 
         let arms = vec![arm1, arm2, arm3];
@@ -180,13 +189,19 @@ mod pattern_tests {
 
         // Check third arm's constructor pattern
         match &result[2].pattern.kind {
-            PatternKind::Struct(name, _) => assert_eq!(name, "Point"),
+            PatternKind::Struct(name, args) => {
+                assert_eq!(name, "Point");
+                assert_eq!(args.len(), 2); // Ensure it has the right number of args
+            }
             _ => panic!("Expected Struct pattern"),
         }
 
         // Test with invalid constructor - should fail
-        let invalid_pattern = ast::Pattern::Constructor(spanned("UnknownType".to_string()), vec![]);
-        let invalid_expr = ast::Expr::Literal(ast::Literal::String("invalid".to_string()));
+        let invalid_pattern = AstPattern::Constructor(
+            spanned("UnknownType".to_string()),
+            vec![spanned(AstPattern::Wildcard), spanned(AstPattern::Wildcard)],
+        );
+        let invalid_expr = ast::Expr::Literal(AstLiteral::String("invalid".to_string()));
         let invalid_arm = create_match_arm(invalid_pattern, invalid_expr);
 
         let invalid_arms = vec![invalid_arm];
@@ -201,15 +216,15 @@ mod pattern_tests {
     fn test_convert_patterns() {
         let mut converter = ASTConverter::default();
 
-        // Register "Point" type for constructor pattern test
-        let point_adt = create_test_adt("Point");
+        // Register "Point" type for constructor pattern test with 2 fields
+        let point_adt = create_product_adt("Point", 2);
         converter
             .type_registry
             .register_adt(&point_adt)
             .expect("Failed to register Point type");
 
         // Test literal pattern
-        let int_pattern = spanned(ast::Pattern::Literal(ast::Literal::Int64(42)));
+        let int_pattern = spanned(AstPattern::Literal(AstLiteral::Int64(42)));
         let result = converter
             .convert_pattern(&int_pattern)
             .expect("Literal pattern conversion should succeed");
@@ -220,7 +235,7 @@ mod pattern_tests {
         }
 
         // Test wildcard pattern
-        let wildcard_pattern = spanned(ast::Pattern::Wildcard);
+        let wildcard_pattern = spanned(AstPattern::Wildcard);
         let result = converter
             .convert_pattern(&wildcard_pattern)
             .expect("Wildcard pattern conversion should succeed");
@@ -231,8 +246,8 @@ mod pattern_tests {
         }
 
         // Test binding pattern
-        let inner = spanned(ast::Pattern::Wildcard);
-        let bind_pattern = spanned(ast::Pattern::Bind(spanned("x".to_string()), inner));
+        let inner = spanned(AstPattern::Wildcard);
+        let bind_pattern = spanned(AstPattern::Bind(spanned("x".to_string()), inner));
 
         let result = converter
             .convert_pattern(&bind_pattern)
@@ -243,10 +258,10 @@ mod pattern_tests {
             _ => panic!("Expected Bind pattern"),
         }
 
-        // Test constructor pattern with registered type
-        let constructor_pattern = spanned(ast::Pattern::Constructor(
+        // Test constructor pattern with registered type and correct field count
+        let constructor_pattern = spanned(AstPattern::Constructor(
             spanned("Point".to_string()),
-            vec![],
+            vec![spanned(AstPattern::Wildcard), spanned(AstPattern::Wildcard)],
         ));
 
         let result = converter
@@ -254,12 +269,15 @@ mod pattern_tests {
             .expect("Constructor pattern conversion should succeed");
 
         match &result.kind {
-            PatternKind::Struct(name, _) => assert_eq!(name, "Point"),
+            PatternKind::Struct(name, fields) => {
+                assert_eq!(name, "Point");
+                assert_eq!(fields.len(), 2);
+            }
             _ => panic!("Expected Struct pattern"),
         }
 
         // Test array patterns
-        let empty_array_pattern = spanned(ast::Pattern::EmptyArray);
+        let empty_array_pattern = spanned(AstPattern::EmptyArray);
         let result = converter
             .convert_pattern(&empty_array_pattern)
             .expect("Empty array pattern conversion should succeed");
@@ -270,9 +288,9 @@ mod pattern_tests {
         }
 
         // Test constructor pattern with unregistered type - should return error
-        let unknown_constructor = spanned(ast::Pattern::Constructor(
+        let unknown_constructor = spanned(AstPattern::Constructor(
             spanned("UnknownType".to_string()),
-            vec![],
+            vec![spanned(AstPattern::Wildcard), spanned(AstPattern::Wildcard)],
         ));
         let result = converter.convert_pattern(&unknown_constructor);
         assert!(
@@ -286,16 +304,16 @@ mod pattern_tests {
         let converter = ASTConverter::default();
 
         // Create a head::tail pattern
-        let head = spanned(ast::Pattern::Bind(
+        let head = spanned(AstPattern::Bind(
             spanned("head".to_string()),
-            spanned(ast::Pattern::Wildcard),
+            spanned(AstPattern::Wildcard),
         ));
-        let tail = spanned(ast::Pattern::Bind(
+        let tail = spanned(AstPattern::Bind(
             spanned("tail".to_string()),
-            spanned(ast::Pattern::Wildcard),
+            spanned(AstPattern::Wildcard),
         ));
 
-        let array_decomp = spanned(ast::Pattern::ArrayDecomp(head, tail));
+        let array_decomp = spanned(AstPattern::ArrayDecomp(head, tail));
 
         let result = converter
             .convert_pattern(&array_decomp)
@@ -323,30 +341,31 @@ mod pattern_tests {
     fn test_nested_constructor_patterns() {
         let mut converter = ASTConverter::default();
 
-        // Register types for nested constructor patterns
-        let types = ["Shape", "Circle", "Rectangle"];
-        for ty in &types {
-            let adt = create_test_adt(ty);
+        // Register types for nested constructor patterns with field counts
+        let types = [("Shape", 1), ("Circle", 1), ("Rectangle", 1)];
+
+        for (name, field_count) in &types {
+            let adt = create_product_adt(name, *field_count);
             converter
                 .type_registry
                 .register_adt(&adt)
-                .unwrap_or_else(|_| panic!("Failed to register {} type", ty));
+                .unwrap_or_else(|_| panic!("Failed to register {} type", name));
         }
 
-        // Test simple constructor pattern
-        let shape_pattern = spanned(ast::Pattern::Constructor(
+        // Test simple constructor pattern with correct field count
+        let shape_pattern = spanned(AstPattern::Constructor(
             spanned("Shape".to_string()),
-            vec![],
+            vec![spanned(AstPattern::Wildcard)],
         ));
         assert!(converter.convert_pattern(&shape_pattern).is_ok());
 
         // Test nested constructor patterns (all valid)
-        let circle_inner = spanned(ast::Pattern::Constructor(
+        let circle_inner = spanned(AstPattern::Constructor(
             spanned("Circle".to_string()),
-            vec![],
+            vec![spanned(AstPattern::Wildcard)],
         ));
 
-        let nested_pattern = spanned(ast::Pattern::Constructor(
+        let nested_pattern = spanned(AstPattern::Constructor(
             spanned("Shape".to_string()),
             vec![circle_inner],
         ));
@@ -358,12 +377,12 @@ mod pattern_tests {
         );
 
         // Test nested with invalid inner constructor
-        let invalid_inner = spanned(ast::Pattern::Constructor(
+        let invalid_inner = spanned(AstPattern::Constructor(
             spanned("InvalidType".to_string()),
-            vec![],
+            vec![spanned(AstPattern::Wildcard)],
         ));
 
-        let invalid_nested = spanned(ast::Pattern::Constructor(
+        let invalid_nested = spanned(AstPattern::Constructor(
             spanned("Shape".to_string()),
             vec![invalid_inner],
         ));
@@ -372,6 +391,58 @@ mod pattern_tests {
         assert!(
             result.is_err(),
             "Nested pattern with invalid constructor should fail"
+        );
+    }
+
+    #[test]
+    fn test_constructor_pattern_field_count_validation() {
+        let mut converter = ASTConverter::default();
+
+        // Register a Point type with 2 fields
+        let point_adt = create_product_adt("Point", 2);
+        converter
+            .type_registry
+            .register_adt(&point_adt)
+            .expect("Failed to register Point type");
+
+        // Test with correct number of arguments (2)
+        let correct_pattern = spanned(AstPattern::Constructor(
+            spanned("Point".to_string()),
+            vec![spanned(AstPattern::Wildcard), spanned(AstPattern::Wildcard)],
+        ));
+
+        let result = converter.convert_pattern(&correct_pattern);
+        assert!(
+            result.is_ok(),
+            "Constructor pattern with correct field count should succeed"
+        );
+
+        // Test with too few arguments (1 instead of 2)
+        let too_few_args = spanned(AstPattern::Constructor(
+            spanned("Point".to_string()),
+            vec![spanned(AstPattern::Wildcard)],
+        ));
+
+        let result = converter.convert_pattern(&too_few_args);
+        assert!(
+            result.is_err(),
+            "Constructor pattern with too few arguments should fail"
+        );
+
+        // Test with too many arguments (3 instead of 2)
+        let too_many_args = spanned(AstPattern::Constructor(
+            spanned("Point".to_string()),
+            vec![
+                spanned(AstPattern::Wildcard),
+                spanned(AstPattern::Wildcard),
+                spanned(AstPattern::Wildcard),
+            ],
+        ));
+
+        let result = converter.convert_pattern(&too_many_args);
+        assert!(
+            result.is_err(),
+            "Constructor pattern with too many arguments should fail"
         );
     }
 }

--- a/optd-dsl/src/analyzer/from_ast/pattern.rs
+++ b/optd-dsl/src/analyzer/from_ast/pattern.rs
@@ -5,8 +5,9 @@
 
 use super::ASTConverter;
 use crate::analyzer::error::AnalyzerErrorKind;
-use crate::analyzer::hir::{Identifier, Literal, MatchArm, Pattern, PatternKind, TypedSpan};
-use crate::parser::ast::{self, Literal as AstLiteral, Pattern as AstPattern};
+use crate::analyzer::hir::{Identifier, MatchArm, Pattern, PatternKind, TypedSpan};
+use crate::analyzer::types::Type;
+use crate::parser::ast::{self, Pattern as AstPattern};
 use crate::utils::span::Spanned;
 use PatternKind::*;
 use std::collections::HashSet;
@@ -43,47 +44,33 @@ impl ASTConverter {
         &self,
         spanned_pattern: &Spanned<AstPattern>,
     ) -> Result<Pattern<TypedSpan>, Box<AnalyzerErrorKind>> {
-        use Literal::*;
-
         let span = spanned_pattern.span.clone();
+        let mut ty = Type::Unknown;
 
         let kind = match &*spanned_pattern.value {
             AstPattern::Error => panic!("AST should no longer contain errors"),
-
             AstPattern::Bind(name, inner_pattern) => {
                 let hir_inner = self.convert_pattern(inner_pattern)?;
                 Bind((*name.value).clone(), hir_inner.into())
             }
-
             AstPattern::Constructor(name, args) => {
                 self.validate_constructor(name, &span, args.len())?;
 
+                ty = Type::Adt(*name.value.clone());
                 let hir_args = args
                     .iter()
                     .map(|arg| self.convert_pattern(arg))
                     .collect::<Result<Vec<_>, _>>()?;
 
-                // Wait until after type inference to transform this into
-                // an operator if needed.
                 Struct((*name.value).clone(), hir_args)
             }
-
             AstPattern::Literal(lit) => {
-                let hir_lit = match lit {
-                    AstLiteral::Int64(val) => Int64(*val),
-                    AstLiteral::String(val) => String(val.clone()),
-                    AstLiteral::Bool(val) => Bool(*val),
-                    AstLiteral::Float64(val) => Float64(val.0),
-                    AstLiteral::Unit => Unit,
-                };
-
+                let (hir_lit, hir_ty) = self.convert_literal(lit);
+                ty = hir_ty;
                 Literal(hir_lit)
             }
-
             AstPattern::Wildcard => Wildcard,
-
             AstPattern::EmptyArray => EmptyArray,
-
             AstPattern::ArrayDecomp(head, tail) => {
                 let hir_head = self.convert_pattern(head)?;
                 let hir_tail = self.convert_pattern(tail)?;
@@ -92,7 +79,7 @@ impl ASTConverter {
             }
         };
 
-        Ok(Pattern::new_unknown(kind, span))
+        Ok(Pattern::new_with(kind, ty, span))
     }
 }
 

--- a/optd-dsl/src/analyzer/types.rs
+++ b/optd-dsl/src/analyzer/types.rs
@@ -31,7 +31,7 @@ pub enum Type {
     // Special types.
     Unit,
     Universe, // All types are subtypes of Universe.
-    Never,    // Inherits all types.
+    Nothing,  // Inherits all types.
     None,     // Inherits all optionals.
     Unknown,
 
@@ -170,8 +170,8 @@ impl TypeRegistry {
             // Universe is the top type - everything is a subtype of Universe
             (_, Universe) => true,
 
-            // Never is the bottom type - it is a subtype of everything
-            (Never, _) => true,
+            // Nothing is the bottom type - it is a subtype of everything
+            (Nothing, _) => true,
 
             (None, Optional(_)) => true,
 
@@ -689,30 +689,30 @@ mod type_registry_tests {
     }
 
     #[test]
-    fn test_never_as_bottom_type() {
+    fn test_nothing_as_bottom_type() {
         let registry = TypeRegistry::default();
 
-        // Never is a subtype of all primitive types
-        assert!(registry.is_subtype(&Type::Never, &Type::Int64));
-        assert!(registry.is_subtype(&Type::Never, &Type::String));
-        assert!(registry.is_subtype(&Type::Never, &Type::Bool));
-        assert!(registry.is_subtype(&Type::Never, &Type::Float64));
-        assert!(registry.is_subtype(&Type::Never, &Type::Unit));
-        assert!(registry.is_subtype(&Type::Never, &Type::Universe));
+        // Nothing is a subtype of all primitive types
+        assert!(registry.is_subtype(&Type::Nothing, &Type::Int64));
+        assert!(registry.is_subtype(&Type::Nothing, &Type::String));
+        assert!(registry.is_subtype(&Type::Nothing, &Type::Bool));
+        assert!(registry.is_subtype(&Type::Nothing, &Type::Float64));
+        assert!(registry.is_subtype(&Type::Nothing, &Type::Unit));
+        assert!(registry.is_subtype(&Type::Nothing, &Type::Universe));
 
-        // Never is a subtype of complex types
-        assert!(registry.is_subtype(&Type::Never, &Type::Array(Box::new(Type::Int64))));
-        assert!(registry.is_subtype(&Type::Never, &Type::Tuple(vec![Type::Int64, Type::Bool])));
+        // Nothing is a subtype of complex types
+        assert!(registry.is_subtype(&Type::Nothing, &Type::Array(Box::new(Type::Int64))));
+        assert!(registry.is_subtype(&Type::Nothing, &Type::Tuple(vec![Type::Int64, Type::Bool])));
         assert!(registry.is_subtype(
-            &Type::Never,
+            &Type::Nothing,
             &Type::Closure(Box::new(Type::Int64), Box::new(Type::Bool))
         ));
 
-        // But no type is a subtype of Never (except Never itself)
-        assert!(!registry.is_subtype(&Type::Int64, &Type::Never));
-        assert!(!registry.is_subtype(&Type::Bool, &Type::Never));
-        assert!(!registry.is_subtype(&Type::Universe, &Type::Never));
-        assert!(!registry.is_subtype(&Type::Array(Box::new(Type::Int64)), &Type::Never));
+        // But no type is a subtype of Nothing (except Nothing itself)
+        assert!(!registry.is_subtype(&Type::Int64, &Type::Nothing));
+        assert!(!registry.is_subtype(&Type::Bool, &Type::Nothing));
+        assert!(!registry.is_subtype(&Type::Universe, &Type::Nothing));
+        assert!(!registry.is_subtype(&Type::Array(Box::new(Type::Int64)), &Type::Nothing));
     }
 
     #[test]
@@ -739,9 +739,9 @@ mod type_registry_tests {
         // None is still a subtype of Universe (as all types are)
         assert!(registry.is_subtype(&Type::None, &Type::Universe));
 
-        // None is not equal to Never
-        assert!(!registry.is_subtype(&Type::None, &Type::Never));
-        assert!(registry.is_subtype(&Type::Never, &Type::None));
+        // None is not equal to Nothing
+        assert!(!registry.is_subtype(&Type::None, &Type::Nothing));
+        assert!(registry.is_subtype(&Type::Nothing, &Type::None));
     }
 
     #[test]

--- a/optd-dsl/src/analyzer/types.rs
+++ b/optd-dsl/src/analyzer/types.rs
@@ -260,7 +260,7 @@ impl TypeRegistry {
         let fields = self
             .product_fields
             .get(adt_name)
-            .expect(&format!("ADT '{}' not found in type registry", adt_name));
+            .unwrap_or_else(|| panic!("ADT '{}' not found in type registry", adt_name));
 
         fields
             .iter()
@@ -285,7 +285,7 @@ impl TypeRegistry {
     pub fn get_field_count(&self, adt_name: &Identifier) -> usize {
         self.product_fields
             .get(adt_name)
-            .expect(&format!("ADT '{}' not found in type registry", adt_name))
+            .unwrap_or_else(|| panic!("ADT '{}' not found in type registry", adt_name))
             .len()
     }
 }

--- a/optd-dsl/src/analyzer/types.rs
+++ b/optd-dsl/src/analyzer/types.rs
@@ -32,6 +32,7 @@ pub enum Type {
     Unit,
     Universe, // All types are subtypes of Universe.
     Never,    // Inherits all types.
+    None,     // Inherits all optionals.
     Unknown,
 
     // User types.
@@ -172,6 +173,8 @@ impl TypeRegistry {
             // Never is the bottom type - it is a subtype of everything
             (Never, _) => true,
 
+            (None, Optional(_)) => true,
+
             // Stored and Costed type handling
             (Stored(child_inner), Stored(parent_inner)) => {
                 self.is_subtype(child_inner, parent_inner)
@@ -235,6 +238,55 @@ impl TypeRegistry {
 
             _ => false,
         }
+    }
+
+    /// Retrieves a field from a product ADT by name.
+    ///
+    /// # Arguments
+    ///
+    /// * `adt_name` - The identifier of the ADT
+    /// * `field_name` - The identifier of the field to retrieve
+    ///
+    /// # Returns
+    ///
+    /// The field with the specified name from the given ADT.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic in two cases:
+    /// 1. If the ADT name doesn't exist in the registry
+    /// 2. If the specified field name doesn't exist in the ADT
+    pub fn get_product_field(&self, adt_name: &Identifier, field_name: &Identifier) -> Field {
+        let fields = self
+            .product_fields
+            .get(adt_name)
+            .expect(&format!("ADT '{}' not found in type registry", adt_name));
+
+        fields
+            .iter()
+            .find(|field| *field.name.value == *field_name)
+            .cloned()
+            .unwrap_or_else(|| panic!("Field '{}' not found in ADT '{}'", field_name, adt_name))
+    }
+
+    /// Returns the number of fields in a product ADT.
+    ///
+    /// # Arguments
+    ///
+    /// * `adt_name` - The identifier of the ADT
+    ///
+    /// # Returns
+    ///
+    /// The number of fields in the specified ADT.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the ADT name doesn't exist in the registry.
+    pub fn get_field_count(&self, adt_name: &Identifier) -> usize {
+        self.product_fields
+            .get(adt_name)
+            .expect(&format!("ADT '{}' not found in type registry", adt_name))
+            .len()
     }
 }
 
@@ -664,6 +716,35 @@ mod type_registry_tests {
     }
 
     #[test]
+    fn test_none_subtyping() {
+        let registry = TypeRegistry::default();
+
+        // Test None as a subtype of any Optional type
+        assert!(registry.is_subtype(&Type::None, &Type::Optional(Box::new(Type::Int64))));
+        assert!(registry.is_subtype(&Type::None, &Type::Optional(Box::new(Type::String))));
+        assert!(registry.is_subtype(&Type::None, &Type::Optional(Box::new(Type::Bool))));
+        assert!(registry.is_subtype(&Type::None, &Type::Optional(Box::new(Type::Float64))));
+        assert!(registry.is_subtype(&Type::None, &Type::Optional(Box::new(Type::Unit))));
+
+        // Test None with complex Optional types
+        assert!(registry.is_subtype(
+            &Type::None,
+            &Type::Optional(Box::new(Type::Array(Box::new(Type::Int64))))
+        ));
+
+        // Test that None is not a subtype of non-Optional types
+        assert!(!registry.is_subtype(&Type::None, &Type::Int64));
+        assert!(!registry.is_subtype(&Type::None, &Type::String));
+
+        // None is still a subtype of Universe (as all types are)
+        assert!(registry.is_subtype(&Type::None, &Type::Universe));
+
+        // None is not equal to Never
+        assert!(!registry.is_subtype(&Type::None, &Type::Never));
+        assert!(registry.is_subtype(&Type::Never, &Type::None));
+    }
+
+    #[test]
     fn test_complex_nested_type_hierarchy() {
         let mut registry = TypeRegistry::default();
 
@@ -748,5 +829,66 @@ mod type_registry_tests {
             &Type::Adt("Truck".to_string()),
             &Type::Adt("Cars".to_string())
         ));
+    }
+
+    #[test]
+    fn test_get_product_field_and_field_count() {
+        let mut registry = TypeRegistry::default();
+
+        // Create an ADT with multiple fields
+        let person = create_product_adt(
+            "Person",
+            vec![
+                ("name", ast::Type::String),
+                ("age", ast::Type::Int64),
+                ("active", ast::Type::Bool),
+            ],
+        );
+
+        // Register the ADT
+        registry.register_adt(&person).unwrap();
+
+        // Test get_field_count
+        assert_eq!(registry.get_field_count(&"Person".to_string()), 3);
+
+        // Test get_product_field
+        let name_field = registry.get_product_field(&"Person".to_string(), &"name".to_string());
+        assert_eq!(*name_field.name.value, "name");
+        match &*name_field.ty.value {
+            ast::Type::String => {} // Expected
+            _ => panic!("Expected String type for name field"),
+        }
+
+        let age_field = registry.get_product_field(&"Person".to_string(), &"age".to_string());
+        assert_eq!(*age_field.name.value, "age");
+        match &*age_field.ty.value {
+            ast::Type::Int64 => {} // Expected
+            _ => panic!("Expected Int64 type for age field"),
+        }
+
+        let active_field = registry.get_product_field(&"Person".to_string(), &"active".to_string());
+        assert_eq!(*active_field.name.value, "active");
+        match &*active_field.ty.value {
+            ast::Type::Bool => {} // Expected
+            _ => panic!("Expected Bool type for active field"),
+        }
+
+        // Test panic behavior with non-existent ADT
+        let result = std::panic::catch_unwind(|| {
+            registry.get_field_count(&"NonExistentADT".to_string());
+        });
+        assert!(
+            result.is_err(),
+            "Expected panic for non-existent ADT in get_field_count"
+        );
+
+        // Test panic behavior with non-existent field
+        let result = std::panic::catch_unwind(|| {
+            registry.get_product_field(&"Person".to_string(), &"nonexistent".to_string());
+        });
+        assert!(
+            result.is_err(),
+            "Expected panic for non-existent field in get_product_field"
+        );
     }
 }

--- a/optd-dsl/src/cli/example.opt
+++ b/optd-dsl/src/cli/example.opt
@@ -1,6 +1,5 @@
 data LogicalProperties(schema_len: I64)
 
-data PhysicalProperties(schema_len: I64)
 
 data Scalar =
     | ColumnRef(idx: I64)
@@ -124,5 +123,5 @@ fn (expr: Logical*) join_commute: Logical? = match expr
         in
             Project(
                 Join(right, left, Inner, cond.remap(remapping)),
-                right_indices.map(i -> ColumnRef(i))
+                right_indices.map(i -> ColumnRef(i)),
             )

--- a/optd-dsl/src/cli/main.rs
+++ b/optd-dsl/src/cli/main.rs
@@ -27,13 +27,11 @@
 //! cargo run -- compile examples/example.opt --print-ast --print-typedspan-hir
 //! ```
 use clap::{Parser, Subcommand};
-use compile::{CompileOptions, adt_check, ast_to_hir, parse, scope_check};
+use optd_dsl::compile::{CompileOptions, adt_check, ast_to_hir, parse, scope_check};
 use optd_dsl::utils::error::{CompileError, Diagnose};
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
-
-mod compile;
 
 #[derive(Parser)]
 #[command(

--- a/optd-dsl/src/compile.rs
+++ b/optd-dsl/src/compile.rs
@@ -1,4 +1,4 @@
-use optd_dsl::{
+use crate::{
     analyzer::{
         error::AnalyzerError,
         from_ast::ASTConverter,

--- a/optd-dsl/src/lib.rs
+++ b/optd-dsl/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod analyzer;
 pub mod catalog;
+pub mod compile;
 pub mod engine;
 pub mod lexer;
 pub mod parser;


### PR DESCRIPTION
### main change

Finalizes semantic analysis by checking for field number mismatches in `Patterns` and `Constructors`.
Displays an error message during the `from_ast` phase, as follows:

![image](https://github.com/user-attachments/assets/0f52d113-9f01-4b47-a160-e67a7a9bac94)

### extra changes

- I added all type annotations I could during the `from_ast` phase, to simplify type inference.
- Added the `none` type, which inherits from Option<Nothing>.
