### PR TITLE
Create `compile_hir` compilation entrypoint.

### DIFF
--- a/optd/src/dsl/cli/main.rs
+++ b/optd/src/dsl/cli/main.rs
@@ -6,34 +6,31 @@
 //!
 //! ```
 //! # Compile a DSL file (parse and analyze):
-//! optd compile path/to/file.op
+//! optd-cli compile path/to/file.opt
 //!
 //! # Compile with verbose output:
-//! optd compile path/to/file.op --verbose
+//! optd-cli compile path/to/file.opt --verbose
 //!
 //! # Print intermediate representations:
-//! optd compile path/to/file.op --print-ast --print-typedspan-hir
+//! optd-cli compile path/to/file.opt --verbose --show-ast --show-typedspan-hir --show-hir
 //!
 //! # Get help:
-//! optd --help
-//! optd compile --help
+//! optd-cli --help
+//! optd-cli compile --help
 //! ```
 //!
 //! When developing, you can run through cargo:
 //!
 //! ```
-//! cargo run -- compile examples/example.opt
-//! cargo run -- compile examples/example.opt --verbose
-//! cargo run -- compile examples/example.opt --print-ast --print-typedspan-hir
+//! cargo run --bin optd-cli -- compile path/to/example.opt
+//! cargo run --bin optd-cli -- compile path/to/example.opt --verbose
+//! cargo run --bin optd-cli -- compile path/to/example.opt --verbose --show-ast --show-hir
 //! ```
 
 use clap::{Parser, Subcommand};
-use colored::*;
-use optd::dsl::compile::{CompileOptions, ast_to_hir, infer, parse, registry_check};
+use colored::Colorize;
+use optd::dsl::compile::{Config, compile_hir};
 use optd::dsl::utils::errors::{CompileError, Diagnose};
-use std::error::Error;
-use std::fs;
-use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(
@@ -50,133 +47,21 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Compile a DSL file (parse and analyze).
-    Compile {
-        /// Input file to compile
-        #[arg(value_name = "FILE")]
-        input: PathBuf,
-
-        /// Print detailed processing information.
-        #[arg(short, long)]
-        verbose: bool,
-
-        /// Print the AST in a readable format.
-        #[arg(long)]
-        print_ast: bool,
-
-        /// Print the typed-span HIR in a readable format.
-        #[arg(long)]
-        print_typedspan_hir: bool,
-    },
+    Compile(Config),
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Vec<CompileError>> {
     let cli = Cli::parse();
 
-    match &cli.command {
-        Commands::Compile {
-            input,
-            verbose,
-            print_ast,
-            print_typedspan_hir,
-        } => {
-            if *verbose {
-                println!("{} Compiling file: {}", "⏳".blue(), input.display());
-            }
-
-            let source = read_file(input)?;
-            let source_path = input.to_string_lossy().to_string();
-
-            let options = CompileOptions {
-                source_path: source_path.clone(),
-            };
-
-            // Step 1: Parse
-            if *verbose {
-                println!("{} Parsing source code...", "→".cyan());
-            }
-
-            let ast = match parse(&source, &options) {
-                Ok(ast) => {
-                    println!("{}", "Parse successful".green());
-                    if *print_ast {
-                        println!("\nAST Structure:\n{:#?}", ast);
-                    }
-                    ast
-                }
-                Err(errors) => handle_errors("Parse failed", &errors),
-            };
-
-            // Step 2: AST to HIR
-            if *verbose {
-                println!("{} Converting AST to HIR and TypeRegistry...", "→".cyan());
-            }
-
-            let (hir, mut type_registry) = match ast_to_hir(&source, ast) {
-                Ok((hir, type_registry)) => {
-                    println!("{}", "AST to HIR conversion successful".green());
-                    if *print_typedspan_hir {
-                        println!("\nTyped-Span HIR Structure:\n{:#?}", hir);
-                    }
-                    (hir, type_registry)
-                }
-                Err(error) => handle_errors("AST to HIR conversion failed", &[error]),
-            };
-
-            // Step 3: TypeRegistry Check
-            if *verbose {
-                println!("{} Checking TypeRegistry...", "→".cyan());
-            }
-
-            match registry_check(&source, &source_path, &type_registry) {
-                Ok(_) => println!("{}", "TypeRegistry check successful".green()),
-                Err(error) => handle_errors("TypeRegistry check failed", &[error]),
-            }
-
-            // Step 4: Type Inference
-            if *verbose {
-                println!("{} Performing type inference...", "→".cyan());
-            }
-
-            match infer(&source, &hir, &mut type_registry) {
-                Ok(_) => {
-                    "Type inference successful".green();
-                    println!("\n{}", "Compilation completed successfully!".green().bold());
-                }
-                Err(errors) => handle_errors("Type inference failed", &errors),
-            }
-        }
-    }
+    let Commands::Compile(config) = cli.command;
+    let _hir = compile_hir(config).unwrap_or_else(|errors| handle_errors(&errors));
 
     Ok(())
 }
 
-fn read_file(path: &PathBuf) -> Result<String, Box<dyn Error>> {
-    match fs::read_to_string(path) {
-        Ok(content) => Ok(content),
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                eprintln!(
-                    "{} {}",
-                    "✘".red().bold(),
-                    format!("File not found: {}", path.display()).red()
-                );
-                eprintln!("  Please check the path and file permissions.\n");
-            } else {
-                eprintln!(
-                    "{} {}",
-                    "✘".red().bold(),
-                    format!("Error reading file: {}", e).red()
-                );
-            }
-            std::process::exit(1);
-        }
-    }
-}
-
-fn handle_errors(msg: &str, errors: &[CompileError]) -> ! {
-    eprintln!("\n{} {}", "✘".red().bold(), msg.red().bold());
+fn handle_errors(errors: &[CompileError]) -> ! {
     eprintln!(
-        "{} {}\n",
+        "\n{} {}\n",
         "•".yellow(),
         format!("{} error(s) encountered:", errors.len()).yellow()
     );

--- a/optd/src/dsl/compile.rs
+++ b/optd/src/dsl/compile.rs
@@ -11,26 +11,156 @@ use crate::dsl::{
     parser::{ast::Module, module::parse_module},
     utils::errors::CompileError,
 };
+use clap::{Args, Parser};
+use colored::Colorize;
+use std::borrow::Cow;
+use std::{fs, path::PathBuf};
 
-/// Compilation options for the DSL.
-pub struct CompileOptions {
-    /// Path to the main module source file.
-    pub source_path: String,
+/// Compilation configuration and options.
+#[derive(Parser)]
+#[command(
+    name = "optd",
+    about = "Optimizer DSL compiler and toolchain",
+    version,
+    author
+)]
+pub struct Config {
+    /// Input file to compile.
+    path: PathBuf,
+    /// The verbosity settings.
+    #[command(flatten)]
+    verbosity: Verbosity,
+}
+
+impl Config {
+    /// A helper method to get the verbosity.
+    fn verbose(&self) -> bool {
+        self.verbosity.verbose
+    }
+
+    /// A helper method to get the path as a string.
+    fn path_str(&self) -> Cow<'_, str> {
+        self.path.to_string_lossy()
+    }
+}
+
+/// Verbosity settings for compilation.
+#[derive(Args)]
+pub struct Verbosity {
+    /// Print detailed processing information.
+    #[arg(long)]
+    verbose: bool,
+    /// Print the AST in a readable format (must enable --verbose).
+    #[arg(long)]
+    show_ast: bool,
+    /// Print the typed-span HIR in a readable format (must enable --verbose).
+    #[arg(long)]
+    show_typedspan_hir: bool,
+    /// Print the final HIR in a readable format (must enable --verbose).
+    #[arg(long)]
+    show_hir: bool,
+}
+
+/// Compiles a file into the [`HIR`].
+///
+/// TODO fix error handling.
+pub fn compile_hir(config: Config) -> Result<HIR, Vec<CompileError>> {
+    let source_path = config.path_str();
+
+    // If we cannot find the file we can't compile anything, so exit immediately.
+    let source = fs::read_to_string(&config.path).unwrap_or_else(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            eprintln!(
+                "{} {}",
+                "✘".red().bold(),
+                format!("File not found: {}", source_path).red()
+            );
+            eprintln!("  Please check the path and file permissions.\n");
+        } else {
+            eprintln!(
+                "{} {}",
+                "✘".red().bold(),
+                format!("Error reading file: {}", e).red()
+            );
+        }
+        std::process::exit(1);
+    });
+
+    // Step 1: Parse.
+    if config.verbose() {
+        println!("{} Compiling file: {}", "⏳".blue(), config.path_str());
+        println!("{} Parsing source code...", "→".cyan());
+    }
+
+    let ast = parse(&source, &config)?;
+
+    if config.verbose() {
+        println!("{}", "Parse successful".green());
+
+        if config.verbosity.show_ast {
+            println!("\nAST Structure:\n{:#?}", ast);
+        }
+    }
+
+    // Step 2: AST to HIR.
+    if config.verbose() {
+        println!("{} Converting AST to HIR and TypeRegistry...", "→".cyan());
+    }
+
+    let (typed_hir, mut type_registry) = ast_to_hir(&source, ast).map_err(|e| vec![e])?;
+
+    if config.verbose() {
+        println!("{}", "AST to HIR conversion successful".green());
+
+        if config.verbosity.show_typedspan_hir {
+            println!("\nTyped-Span HIR Structure:\n{:#?}", typed_hir);
+        }
+    }
+
+    // Step 3: TypeRegistry Check.
+    if config.verbose() {
+        println!("{} Checking TypeRegistry...", "→".cyan());
+    }
+
+    registry_check(&source, &source_path, &type_registry).map_err(|e| vec![e])?;
+
+    if config.verbose() {
+        println!("{}", "TypeRegistry check successful".green());
+    }
+
+    // Step 4: Type Inference.
+    if config.verbose() {
+        println!("{} Performing type inference...", "→".cyan());
+    }
+
+    let hir = infer(&source, &typed_hir, &mut type_registry)?;
+
+    if config.verbose() {
+        println!("{}", "Type inference successful".green());
+
+        if config.verbosity.show_hir {
+            println!("\nTyped-Span HIR Structure:\n{:#?}", hir);
+        }
+
+        println!("\n{}", "Compilation completed successfully!".green().bold());
+    }
+
+    Ok(hir)
 }
 
 /// Parse DSL source code to AST.
 ///
 /// This function performs lexing and parsing stages of compilation,
 /// returning either the parsed AST Module or collected errors.
-pub fn parse(source: &str, options: &CompileOptions) -> Result<Module, Vec<CompileError>> {
+pub fn parse(source: &str, config: &Config) -> Result<Module, Vec<CompileError>> {
     let mut errors = Vec::new();
     // Step 1: Lexing
-    let (tokens_opt, lex_errors) = lex(source, &options.source_path);
+    let (tokens_opt, lex_errors) = lex(source, &config.path_str());
     errors.extend(lex_errors);
     match tokens_opt {
         Some(tokens) => {
             // Step 2: Parsing
-            let (ast_opt, parse_errors) = parse_module(tokens, source, &options.source_path);
+            let (ast_opt, parse_errors) = parse_module(tokens, source, &config.path_str());
             errors.extend(parse_errors);
             match ast_opt {
                 Some(ast) if errors.is_empty() => Ok(ast),


### PR DESCRIPTION
## Problem

The only place one could compile an HIR was through the `optd-cli` binary. This PR brings this behavior back into the library so we can extend its functionality with UDFs (in a future PR).

## Summary of changes

Created a `Config` struct inside `compile.rs` that largely mimics the previous `clap` struct but cleans it up a bit. This `Config` contains a flattened `Verbosity` struct that groups the different verbosity settings together when compiling. This makes it much easier to pass all of the configurations directly to functions without expanding the fields.

The `compile_hir` function is also located in `compile.rs`, and it largely copies the function that was previously in `optd/src/dsl/cli/main.rs`. This will make it easy to modify what we can pass into compilation (namely a function table for UDFs).