### PR TITLE
Implement UDF linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +703,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -837,7 +861,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -849,6 +875,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1155,6 +1190,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,10 +1370,25 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
+ "tokio",
  "typed-builder 0.20.1",
  "url",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "iceberg-catalog-memory"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94438e70602c1cc37c8de0e0f8925a703092be41da5046c9252fb9859b58a908"
+dependencies = [
+ "async-trait",
+ "futures",
+ "iceberg",
+ "itertools",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -1890,6 +1958,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
+ "crc32c",
  "flagset",
  "futures",
  "getrandom 0.2.15",
@@ -1898,7 +1967,8 @@ dependencies = [
  "md-5",
  "once_cell",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.36.2",
+ "reqsign",
  "reqwest",
  "serde",
  "serde_json",
@@ -1919,6 +1989,7 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "iceberg",
+ "iceberg-catalog-memory",
  "ordered-float 5.0.0",
  "tokio",
  "trait-variant",
@@ -1949,6 +2020,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2130,6 +2211,16 @@ name = "quick-xml"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
 dependencies = [
  "memchr",
  "serde",
@@ -2338,6 +2429,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqsign"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9323c0afb30e54f793f4705b10c890395bccc87c6e6ea62c4e7e82d09a380dc6"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "chrono",
+ "form_urlencoded",
+ "getrandom 0.2.15",
+ "hex",
+ "hmac",
+ "home",
+ "http",
+ "log",
+ "percent-encoding",
+ "quick-xml 0.37.4",
+ "rand 0.8.5",
+ "reqwest",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2549,17 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
+]
 
 [[package]]
 name = "rust_decimal"
@@ -2645,6 +2775,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3088,6 +3240,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"

--- a/optd/Cargo.toml
+++ b/optd/Cargo.toml
@@ -18,6 +18,7 @@ colored = "3.0.0"
 enum_dispatch = "0.3.13"
 futures = "0.3.31"
 iceberg = { version = "0.4.0", default-features = false }
+iceberg-catalog-memory = "0.4.0"
 ordered-float = "5.0.0"
 tokio = { version = "1.44.2", features = ["macros", "rt"] }
 trait-variant = "0.1.2"

--- a/optd/src/catalog/iceberg.rs
+++ b/optd/src/catalog/iceberg.rs
@@ -11,8 +11,8 @@ use std::{collections::HashMap, sync::Arc};
 /// TODO(connor): For now, keep everything in the default namespace for simplicity.
 static DEFAULT_NAMESPACE: &str = "default";
 
-/// A wrapper around an arbitrary Iceberg catalog.
-#[derive(Debug)]
+/// A wrapper around an arbitrary Iceberg Catalog.
+#[derive(Debug, Clone)]
 pub struct OptdIcebergCatalog<C: IcebergCatalog>(Arc<C>);
 
 impl<C: IcebergCatalog> OptdIcebergCatalog<C> {
@@ -30,7 +30,6 @@ impl<C: IcebergCatalog> OptdIcebergCatalog<C> {
         let namespace_ident = NamespaceIdent::new(DEFAULT_NAMESPACE.to_string());
         let table_ident = TableIdent::new(namespace_ident, table_name.to_string());
 
-        // TODO(connor): FIX ERROR HANDLING.
         self.0
             .load_table(&table_ident)
             .await
@@ -38,7 +37,7 @@ impl<C: IcebergCatalog> OptdIcebergCatalog<C> {
     }
 }
 
-/// Creates an in-memory catalog.
+/// Creates a basic in-memory catalog. Used for testing.
 pub fn memory_catalog() -> OptdIcebergCatalog<MemoryCatalog> {
     let file_io = FileIOBuilder::new("memory")
         .build()

--- a/optd/src/catalog/iceberg.rs
+++ b/optd/src/catalog/iceberg.rs
@@ -1,7 +1,10 @@
 use super::{Catalog as OptdCatalog, CatalogError};
 use async_trait::async_trait;
-use iceberg::{Catalog as IcebergCatalog, NamespaceIdent, TableIdent, table::Table};
-use std::collections::HashMap;
+use iceberg::{
+    Catalog as IcebergCatalog, NamespaceIdent, TableIdent, io::FileIOBuilder, table::Table,
+};
+use iceberg_catalog_memory::MemoryCatalog;
+use std::{collections::HashMap, sync::Arc};
 
 /// The default namespace for the Iceberg catalog.
 ///
@@ -10,11 +13,15 @@ static DEFAULT_NAMESPACE: &str = "default";
 
 /// A wrapper around an arbitrary Iceberg catalog.
 #[derive(Debug)]
-pub struct OptdIcebergCatalog<C: IcebergCatalog>(C);
+pub struct OptdIcebergCatalog<C: IcebergCatalog>(Arc<C>);
 
 impl<C: IcebergCatalog> OptdIcebergCatalog<C> {
     /// Creates a new catalog.
     pub fn new(catalog: C) -> Self {
+        Self(Arc::new(catalog))
+    }
+
+    pub fn new_from_arc(catalog: Arc<C>) -> Self {
         Self(catalog)
     }
 
@@ -29,6 +36,16 @@ impl<C: IcebergCatalog> OptdIcebergCatalog<C> {
             .await
             .map_err(|e| CatalogError::Unknown(e.to_string()))
     }
+}
+
+/// Creates an in-memory catalog.
+pub fn memory_catalog() -> OptdIcebergCatalog<MemoryCatalog> {
+    let file_io = FileIOBuilder::new("memory")
+        .build()
+        .expect("unable to create file");
+    let catalog = Arc::new(MemoryCatalog::new(file_io, Some("mock".to_string())));
+
+    OptdIcebergCatalog(catalog)
 }
 
 #[async_trait]

--- a/optd/src/core/optimizer/jobs.rs
+++ b/optd/src/core/optimizer/jobs.rs
@@ -269,7 +269,7 @@ impl<M: Memoize> Optimizer<M> {
         expression_id: LogicalExpressionId,
         job_id: JobId,
     ) -> Result<(), Error> {
-        let engine = Engine::new(self.hir_context.clone());
+        let engine = Engine::new(self.hir_context.clone(), self.catalog.clone());
 
         let plan: PartialLogicalPlan = self
             .memo
@@ -311,7 +311,7 @@ impl<M: Memoize> Optimizer<M> {
         group_id: GroupId,
         job_id: JobId,
     ) -> Result<(), Error> {
-        let engine = Engine::new(self.hir_context.clone());
+        let engine = Engine::new(self.hir_context.clone(), self.catalog.clone());
 
         let plan: PartialLogicalPlan = self
             .memo
@@ -350,7 +350,7 @@ impl<M: Memoize> Optimizer<M> {
         goal_id: GoalId,
         job_id: JobId,
     ) -> Result<(), Error> {
-        let engine = Engine::new(self.hir_context.clone());
+        let engine = Engine::new(self.hir_context.clone(), self.catalog.clone());
 
         let Goal(_, physical_props) = self.memo.materialize_goal(goal_id).await?;
         let plan = self
@@ -389,7 +389,7 @@ impl<M: Memoize> Optimizer<M> {
         expression_id: PhysicalExpressionId,
         job_id: JobId,
     ) -> Result<(), Error> {
-        let engine = Engine::new(self.hir_context.clone());
+        let engine = Engine::new(self.hir_context.clone(), self.catalog.clone());
 
         let plan = self.egest_partial_plan(expression_id).await?;
 

--- a/optd/src/core/optimizer/mod.rs
+++ b/optd/src/core/optimizer/mod.rs
@@ -1,3 +1,4 @@
+use crate::catalog::Catalog;
 use crate::core::cir::{
     Cost, Goal, GoalId, GroupId, LogicalExpressionId, LogicalPlan, LogicalProperties,
     PartialLogicalPlan, PartialPhysicalPlan, PhysicalExpressionId, PhysicalPlan, RuleBook,
@@ -15,6 +16,7 @@ use futures::{
 };
 use jobs::{Job, JobId};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 use tasks::{Task, TaskId};
 
 mod egest;
@@ -104,6 +106,7 @@ pub struct Optimizer<M: Memoize> {
     memo: M,
     rule_book: RuleBook,
     hir_context: Context,
+    catalog: Arc<dyn Catalog>,
 
     // Message handling.
     pending_messages: Vec<PendingMessage>,
@@ -139,6 +142,7 @@ impl<M: Memoize> Optimizer<M> {
     fn new(
         memo: M,
         hir: HIR,
+        catalog: Arc<dyn Catalog>,
         message_tx: Sender<OptimizerMessage>,
         message_rx: Receiver<OptimizerMessage>,
         optimize_rx: Receiver<OptimizeRequest>,
@@ -148,6 +152,7 @@ impl<M: Memoize> Optimizer<M> {
             memo,
             rule_book: RuleBook::default(),
             hir_context: hir.context,
+            catalog,
 
             // Message handling.
             pending_messages: Vec::new(),
@@ -178,12 +183,19 @@ impl<M: Memoize> Optimizer<M> {
     }
 
     /// Launch a new optimizer and return a sender for client communication.
-    pub fn launch(memo: M, hir: HIR) -> Sender<OptimizeRequest> {
+    pub fn launch(memo: M, hir: HIR, catalog: Arc<dyn Catalog>) -> Sender<OptimizeRequest> {
         let (message_tx, message_rx) = mpsc::channel(0);
         let (optimize_tx, optimize_rx) = mpsc::channel(0);
 
         // Start the background processing loop.
-        let optimizer = Self::new(memo, hir, message_tx.clone(), message_rx, optimize_rx);
+        let optimizer = Self::new(
+            memo,
+            hir,
+            catalog,
+            message_tx.clone(),
+            message_rx,
+            optimize_rx,
+        );
         tokio::spawn(async move {
             // TODO(Alexis): If an error occurs we could restart or reboot the memo.
             // Rather than failing (e.g. memo could be distributed).

--- a/optd/src/dsl/analyzer/errors.rs
+++ b/optd/src/dsl/analyzer/errors.rs
@@ -275,15 +275,12 @@ impl Diagnose for Box<AnalyzerError> {
                 .with_help("Add at least one parameter or a receiver to this function")
                 .with_note("Functions without parameters are not supported in this language")
                 .finish(),
-            UnknownUdf { name, span } => Report::build(ReportKind::Error, span.clone())
-                .with_message(format!("Unknown UDF found: '{}'", name))
-                .with_label(
-                    Label::new(span.clone())
-                        .with_message("UDF linker error")
-                        .with_color(Color::Magenta),
-                )
-                .with_help(format!("Ensure that the UDF {} is provided before compilation", name))
-                .finish(),
+            UnknownUdf { name, span } => self.build_single_span_report(
+                span,
+                &format!("Undefined UDF named: '{}'", name),
+                &format!("'{}' is not a valid UDF", name),
+                &format!("Ensure that the UDF {} is provided before compilation", name),
+            ),
             UndefinedReference { name, span } => self.build_single_span_report(
                 span,
                 &format!("Undefined reference to: '{}'", name),

--- a/optd/src/dsl/analyzer/errors.rs
+++ b/optd/src/dsl/analyzer/errors.rs
@@ -43,6 +43,11 @@ pub enum AnalyzerErrorKind {
         span: Span,
     },
 
+    UnknownUdf {
+        name: String,
+        span: Span,
+    },
+
     UndefinedReference {
         name: String,
         span: Span,
@@ -122,6 +127,14 @@ impl AnalyzerErrorKind {
 
     pub fn new_incomplete_function(name: &str, span: &Span) -> Box<Self> {
         Self::IncompleteFunction {
+            name: name.to_string(),
+            span: span.clone(),
+        }
+        .into()
+    }
+
+    pub fn new_unknown_udf(name: &str, span: &Span) -> Box<Self> {
+        Self::UnknownUdf {
             name: name.to_string(),
             span: span.clone(),
         }
@@ -262,6 +275,15 @@ impl Diagnose for Box<AnalyzerError> {
                 .with_help("Add at least one parameter or a receiver to this function")
                 .with_note("Functions without parameters are not supported in this language")
                 .finish(),
+            UnknownUdf { name, span } => Report::build(ReportKind::Error, span.clone())
+                .with_message(format!("Unknown UDF found: '{}'", name))
+                .with_label(
+                    Label::new(span.clone())
+                        .with_message("UDF linker error")
+                        .with_color(Color::Magenta),
+                )
+                .with_help(format!("Ensure that the UDF {} is provided before compilation", name))
+                .finish(),
             UndefinedReference { name, span } => self.build_single_span_report(
                 span,
                 &format!("Undefined reference to: '{}'", name),
@@ -347,6 +369,7 @@ impl Diagnose for Box<AnalyzerError> {
             DuplicateAdt { duplicate_span, .. } => duplicate_span,
             DuplicateIdentifier { duplicate_span, .. } => duplicate_span,
             IncompleteFunction { span, .. } => span,
+            UnknownUdf { span, .. } => span,
             UndefinedReference { span, .. } => span,
             CyclicType { path } => &path[0].span,
             UndefinedType { span, .. } => span,

--- a/optd/src/dsl/analyzer/from_ast/converter.rs
+++ b/optd/src/dsl/analyzer/from_ast/converter.rs
@@ -1,14 +1,13 @@
 use crate::dsl::analyzer::errors::AnalyzerErrorKind;
-use crate::dsl::analyzer::hir::{Annotation, FunKind, Identifier, UdfKind};
+use crate::dsl::analyzer::hir::{Annotation, FunKind, Identifier};
 use crate::dsl::analyzer::types::registry::{Type, TypeRegistry, create_function_type};
 use crate::dsl::analyzer::{
     context::Context,
-    hir::{CoreData, HIR, TypedSpan, Value},
+    hir::{CoreData, HIR, TypedSpan, Udf, Value},
 };
 use crate::dsl::parser::ast::{Function, Item, Module};
 use crate::dsl::utils::span::Spanned;
 use FunKind::*;
-use UdfKind::*;
 use std::collections::{HashMap, HashSet};
 
 /// Converts an AST to a High-level Intermediate Representation (HIR).
@@ -20,6 +19,19 @@ pub struct ASTConverter {
     pub(super) registry: TypeRegistry,
     /// Annotations for HIR expressions.
     pub(super) annotations: HashMap<Identifier, Vec<Annotation>>,
+    /// User-defined functions.
+    pub(super) udfs: HashMap<String, Udf>,
+}
+
+impl ASTConverter {
+    pub fn new_with_udfs(udfs: HashMap<String, Udf>) -> Self {
+        ASTConverter {
+            context: Default::default(),
+            registry: Default::default(),
+            annotations: Default::default(),
+            udfs,
+        }
+    }
 }
 
 impl ASTConverter {
@@ -110,12 +122,14 @@ impl ASTConverter {
                 self.context.try_bind(name.clone(), fn_value)?;
             }
             None => {
+                let udf = self
+                    .udfs
+                    .get(name)
+                    .ok_or_else(|| AnalyzerErrorKind::new_unknown_udf(name, &fn_span))?
+                    .clone();
+
                 // Process external function (UDF).
-                let fn_value = Value::new_with(
-                    CoreData::Function(Udf(Unlinked(name.clone()))),
-                    fn_type,
-                    fn_span,
-                );
+                let fn_value = Value::new_with(CoreData::Function(Udf(udf)), fn_type, fn_span);
 
                 self.context.try_bind(name.clone(), fn_value)?;
             }
@@ -177,6 +191,7 @@ impl ASTConverter {
 #[cfg(test)]
 mod converter_tests {
     use super::*;
+    use crate::catalog::Catalog;
     use crate::dsl::analyzer::hir::{CoreData, FunKind};
     use crate::dsl::parser::ast::{self, Adt, Function, Item, Module, Type as AstType};
     use crate::dsl::utils::span::{Span, Spanned};
@@ -377,29 +392,55 @@ mod converter_tests {
     }
 
     #[test]
-    fn test_process_external_function() {
-        // Create an external function (no body)
+    fn test_process_external_function_link() {
+        // Create an external function that will not be linked.
         let ext_func = create_simple_function("external_function", false);
         let module = create_module_with_functions(vec![ext_func]);
 
-        // Create and run the converter
-        let converter = ASTConverter::default();
+        pub fn external_function(_args: &[Value], _catalog: &dyn Catalog) -> Value {
+            println!("Hello from UDF!");
+            Value::new(CoreData::<Value>::None)
+        }
+
+        // Link the dummy function.
+        let mut udfs = HashMap::new();
+        let udf = Udf {
+            func: external_function,
+        };
+        udfs.insert("external_function".to_string(), udf);
+
+        // Run the converter.
+        let converter = ASTConverter::new_with_udfs(udfs);
         let result = converter.convert(&module);
 
-        // Verify result is Ok and contains the expected function
+        // There should be no error if linking succeeded.
         assert!(result.is_ok());
         let (hir, _registry) = result.unwrap();
 
-        // Check that function is in the context
+        // Check that the function is in the context.
         let func_val = hir.context.lookup("external_function");
         assert!(func_val.is_some());
 
-        // Verify it's an unlinked UDF
-        if let CoreData::Function(FunKind::Udf(UdfKind::Unlinked(name))) = &func_val.unwrap().data {
-            assert_eq!(name, "external_function");
+        // Verify it is the same function pointer.
+        if let CoreData::Function(FunKind::Udf(udf)) = &func_val.unwrap().data {
+            assert_eq!(udf.func as usize, external_function as usize);
         } else {
             panic!("Expected unlinked UDF");
         }
+    }
+
+    #[test]
+    fn test_process_external_function_fail() {
+        // Create an external function that will not be linked.
+        let ext_func = create_simple_function("external_function", false);
+        let module = create_module_with_functions(vec![ext_func]);
+
+        // Create and run the converter.
+        let converter = ASTConverter::default();
+        let result = converter.convert(&module);
+
+        // Verify that an error is raised.
+        assert!(result.is_err());
     }
 
     #[test]

--- a/optd/src/dsl/analyzer/hir.rs
+++ b/optd/src/dsl/analyzer/hir.rs
@@ -81,10 +81,12 @@ impl Udf {
     }
 }
 
-/// Types of functions in the system
+/// The different kinds of functions in the system.
 #[derive(Debug, Clone)]
 pub enum FunKind<M: ExprMetadata = NoMetadata> {
     Closure(Vec<Identifier>, Arc<Expr<M>>),
+    /// A user-defined function. Note that the [`Value`] type passed to [`Udf`]s do not carry any
+    /// metadata like `Value<TypedSpan>`.
     Udf(Udf),
 }
 

--- a/optd/src/dsl/analyzer/hir.rs
+++ b/optd/src/dsl/analyzer/hir.rs
@@ -18,6 +18,7 @@
 use super::context::Context;
 use super::map::Map;
 use super::types::registry::Type;
+use crate::catalog::Catalog;
 use crate::dsl::utils::span::Span;
 use std::fmt::Debug;
 use std::{collections::HashMap, sync::Arc};
@@ -66,18 +67,25 @@ impl TypedSpan {
     }
 }
 
-/// User-defined function: either linked or unlinked
 #[derive(Debug, Clone)]
-pub enum UdfKind<M: ExprMetadata> {
-    Linked(fn(Vec<Value<M>>) -> Value<M>),
-    Unlinked(Identifier),
+pub struct Udf {
+    /// The function pointer to the user-defined function.
+    ///
+    /// Note that [`Value`]s passed to and returned from this UDF do not have associated metadata.
+    pub func: fn(&[Value], &dyn Catalog) -> Value,
+}
+
+impl Udf {
+    pub fn call(&self, values: &[Value], catalog: &dyn Catalog) -> Value {
+        (self.func)(values, catalog)
+    }
 }
 
 /// Types of functions in the system
 #[derive(Debug, Clone)]
-pub enum FunKind<M: ExprMetadata> {
+pub enum FunKind<M: ExprMetadata = NoMetadata> {
     Closure(Vec<Identifier>, Arc<Expr<M>>),
-    Udf(UdfKind<M>),
+    Udf(Udf),
 }
 
 /// Group identifier in the optimizer
@@ -294,7 +302,7 @@ pub type MapEntry<M> = (Arc<Expr<M>>, Arc<Expr<M>>);
 
 /// Expression node kinds without metadata
 #[derive(Debug, Clone)]
-pub enum ExprKind<M: ExprMetadata> {
+pub enum ExprKind<M: ExprMetadata = NoMetadata> {
     /// Pattern matching expression
     PatternMatch(Arc<Expr<M>>, Vec<MatchArm<M>>),
     /// Conditional expression
@@ -387,7 +395,7 @@ impl Pattern<TypedSpan> {
 
 /// Pattern node kinds without metadata
 #[derive(Debug, Clone)]
-pub enum PatternKind<M: ExprMetadata> {
+pub enum PatternKind<M: ExprMetadata = NoMetadata> {
     /// Bind a value to a name
     Bind(Identifier, Box<Pattern<M>>),
     /// Match a literal value

--- a/optd/src/dsl/cli/main.rs
+++ b/optd/src/dsl/cli/main.rs
@@ -27,8 +27,12 @@
 //! cargo run --bin optd-cli -- compile path/to/example.opt --verbose --show-ast --show-hir
 //! ```
 
+use std::collections::HashMap;
+
 use clap::{Parser, Subcommand};
 use colored::Colorize;
+use optd::catalog::Catalog;
+use optd::dsl::analyzer::hir::{CoreData, Udf, Value};
 use optd::dsl::compile::{Config, compile_hir};
 use optd::dsl::utils::errors::{CompileError, Diagnose};
 
@@ -50,11 +54,23 @@ enum Commands {
     Compile(Config),
 }
 
+pub fn temp_fake_udf(_args: &[Value], _catalog: &dyn Catalog) -> Value {
+    println!("Hello from UDF!");
+    Value::new(CoreData::<Value>::None)
+}
+
 fn main() -> Result<(), Vec<CompileError>> {
     let cli = Cli::parse();
 
+    let mut udfs = HashMap::new();
+    let udf = Udf {
+        func: temp_fake_udf,
+    };
+    udfs.insert("temp_fake_udf".to_string(), udf);
+
     let Commands::Compile(config) = cli.command;
-    let _hir = compile_hir(config).unwrap_or_else(|errors| handle_errors(&errors));
+
+    let _hir = compile_hir(config, udfs).unwrap_or_else(|errors| handle_errors(&errors));
 
     Ok(())
 }

--- a/optd/src/dsl/cli/main.rs
+++ b/optd/src/dsl/cli/main.rs
@@ -54,7 +54,8 @@ enum Commands {
     Compile(Config),
 }
 
-pub fn temp_fake_udf(_args: &[Value], _catalog: &dyn Catalog) -> Value {
+/// A simple user-defined function.
+pub fn hello_udf(_args: &[Value], _catalog: &dyn Catalog) -> Value {
     println!("Hello from UDF!");
     Value::new(CoreData::<Value>::None)
 }
@@ -63,10 +64,8 @@ fn main() -> Result<(), Vec<CompileError>> {
     let cli = Cli::parse();
 
     let mut udfs = HashMap::new();
-    let udf = Udf {
-        func: temp_fake_udf,
-    };
-    udfs.insert("temp_fake_udf".to_string(), udf);
+    let udf = Udf { func: hello_udf };
+    udfs.insert("hello_udf".to_string(), udf);
 
     let Commands::Compile(config) = cli.command;
 

--- a/optd/src/dsl/compile.rs
+++ b/optd/src/dsl/compile.rs
@@ -3,7 +3,7 @@ use crate::dsl::{
         context::Context,
         errors::AnalyzerError,
         from_ast::ASTConverter,
-        hir::{HIR, TypedSpan},
+        hir::{HIR, TypedSpan, Udf},
         semantic_checks::adt_check,
         types::registry::TypeRegistry,
     },
@@ -13,7 +13,7 @@ use crate::dsl::{
 };
 use clap::{Args, Parser};
 use colored::Colorize;
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 use std::{fs, path::PathBuf};
 
 /// Compilation configuration and options.
@@ -64,7 +64,7 @@ pub struct Verbosity {
 /// Compiles a file into the [`HIR`].
 ///
 /// TODO fix error handling.
-pub fn compile_hir(config: Config) -> Result<HIR, Vec<CompileError>> {
+pub fn compile_hir(config: Config, udfs: HashMap<String, Udf>) -> Result<HIR, Vec<CompileError>> {
     let source_path = config.path_str();
 
     // If we cannot find the file we can't compile anything, so exit immediately.
@@ -107,7 +107,7 @@ pub fn compile_hir(config: Config) -> Result<HIR, Vec<CompileError>> {
         println!("{} Converting AST to HIR and TypeRegistry...", "→".cyan());
     }
 
-    let (typed_hir, mut type_registry) = ast_to_hir(&source, ast).map_err(|e| vec![e])?;
+    let (typed_hir, mut type_registry) = ast_to_hir(&source, ast, udfs).map_err(|e| vec![e])?;
 
     if config.verbose() {
         println!("{}", "AST to HIR conversion successful".green());
@@ -178,8 +178,9 @@ pub fn parse(source: &str, config: &Config) -> Result<Module, Vec<CompileError>>
 pub fn ast_to_hir(
     source: &str,
     ast: Module,
+    udfs: HashMap<String, Udf>,
 ) -> Result<(HIR<TypedSpan>, TypeRegistry), CompileError> {
-    let converter = ASTConverter::default();
+    let converter = ASTConverter::new_with_udfs(udfs);
     converter.convert(&ast).map_err(|err_kind| {
         CompileError::AnalyzerError(AnalyzerError::new(source.to_string(), *err_kind))
     })

--- a/optd/src/dsl/engine/eval/core.rs
+++ b/optd/src/dsl/engine/eval/core.rs
@@ -94,6 +94,7 @@ impl<O: Clone + Send + 'static> Engine<O> {
 
 #[cfg(test)]
 mod tests {
+    use crate::catalog::iceberg::memory_catalog;
     use crate::dsl::analyzer::hir::{BinOp, LetBinding};
     use crate::dsl::utils::tests::{
         TestHarness, evaluate_and_collect, int, lit_expr, ref_expr, string,
@@ -112,7 +113,8 @@ mod tests {
     #[tokio::test]
     async fn test_literal_evaluation() {
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
         let harness = TestHarness::new();
 
         // Create a literal expression
@@ -134,7 +136,8 @@ mod tests {
     async fn test_array_evaluation() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create an array expression with values to evaluate
         let array_expr = Arc::new(Expr::new(CoreExpr(CoreData::Array(vec![
@@ -172,7 +175,8 @@ mod tests {
     async fn test_tuple_evaluation() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a tuple expression with mixed types
         let tuple_expr = Arc::new(Expr::new(CoreExpr(CoreData::Tuple(vec![
@@ -210,7 +214,8 @@ mod tests {
     async fn test_struct_evaluation() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a struct expression
         let struct_expr = Arc::new(Expr::new(CoreExpr(CoreData::Struct(
@@ -244,7 +249,8 @@ mod tests {
     async fn test_function_evaluation() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a function expression (just a simple closure)
         let fn_expr = Arc::new(Expr::new(CoreExpr(CoreData::Function(FunKind::Closure(
@@ -269,7 +275,8 @@ mod tests {
     async fn test_null_evaluation() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a null expression
         let null_expr = Arc::new(Expr::new(CoreExpr(CoreData::None)));
@@ -323,7 +330,8 @@ mod tests {
         let mut ctx = Context::default();
         ctx.bind("fail_fn".to_string(), fail_fn);
         ctx.bind("main_fn".to_string(), main_fn);
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // This should not run the addition, but should escape to the function return with the error message
         let call_expr = Arc::new(Expr::new(Call(ref_expr("main_fn"), vec![])));

--- a/optd/src/dsl/engine/eval/expr.rs
+++ b/optd/src/dsl/engine/eval/expr.rs
@@ -2,7 +2,7 @@ use super::{binary::eval_binary_op, unary::eval_unary_op};
 use crate::capture;
 use crate::dsl::analyzer::hir::{
     BinOp, CoreData, Expr, ExprKind, FunKind, Goal, GroupId, Identifier, LetBinding, Literal,
-    LogicalOp, Materializable, PhysicalOp, UdfKind, UnaryOp, Value,
+    LogicalOp, Materializable, PhysicalOp, Udf, UnaryOp, Value,
 };
 use crate::dsl::analyzer::map::Map;
 use crate::dsl::engine::{Continuation, Engine, EngineResponse};
@@ -219,7 +219,7 @@ impl<O: Clone + Send + 'static> Engine<O> {
                         CoreData::Function(FunKind::Closure(params, body)) => {
                             engine.evaluate_closure_call(params, body, args, k).await
                         }
-                        CoreData::Function(FunKind::Udf(UdfKind::Linked(udf))) => {
+                        CoreData::Function(FunKind::Udf(udf)) => {
                             engine.evaluate_rust_udf_call(udf, args, k).await
                         }
 
@@ -576,16 +576,18 @@ impl<O: Clone + Send + 'static> Engine<O> {
     /// * `k` - The continuation to receive evaluation results
     pub(crate) async fn evaluate_rust_udf_call(
         self,
-        udf: fn(Vec<Value>) -> Value,
+        udf: Udf,
         args: Vec<Arc<Expr>>,
         k: Continuation<Value, EngineResponse<O>>,
     ) -> EngineResponse<O> {
+        let catalog = Arc::clone(&self.catalog);
+
         self.evaluate_sequence(
             args,
             Arc::new(move |arg_values| {
-                Box::pin(capture!([udf, k], async move {
+                Box::pin(capture!([udf, catalog, k], async move {
                     // Call the UDF with the argument values.
-                    let result = udf(arg_values);
+                    let result = udf.call(&arg_values, catalog.as_ref());
 
                     // Pass the result to the continuation.
                     k(result).await
@@ -671,7 +673,8 @@ impl<O: Clone + Send + 'static> Engine<O> {
 
 #[cfg(test)]
 mod tests {
-    use crate::dsl::analyzer::hir::{Goal, GroupId, LetBinding, Materializable, UdfKind};
+    use crate::catalog::iceberg::memory_catalog;
+    use crate::dsl::analyzer::hir::{Goal, GroupId, LetBinding, Materializable, Udf};
     use crate::dsl::engine::Engine;
     use crate::dsl::utils::tests::{
         array_val, assert_values_equal, create_logical_operator, create_physical_operator,
@@ -693,7 +696,8 @@ mod tests {
     async fn test_if_then_else() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog.clone());
 
         // if true then "yes" else "no"
         let true_condition = Arc::new(Expr::new(IfThenElse(
@@ -716,7 +720,7 @@ mod tests {
         // Let's create a more complex condition: if x > 10 then x * 2 else x / 2
         let mut ctx = Context::default();
         ctx.bind("x".to_string(), lit_val(int(20)));
-        let engine_with_x = Engine::new(ctx);
+        let engine_with_x = Engine::new(ctx, catalog);
 
         let complex_condition = Arc::new(Expr::new(IfThenElse(
             Arc::new(Expr::new(Binary(
@@ -765,7 +769,8 @@ mod tests {
     async fn test_let_binding() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // let x = 10 in x + 5
         let let_expr = Arc::new(Expr::new(Let(
@@ -794,7 +799,8 @@ mod tests {
         let mut ctx = Context::default();
         // Bind a variable in the outer scope
         ctx.bind("x".to_string(), lit_val(int(10)));
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create an inner let binding to shadow x
         let inner_let = Arc::new(Expr::new(Let(
@@ -845,7 +851,8 @@ mod tests {
     async fn test_evaluate_binary_logical() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Test direct binary expression evaluation for AND operator
         // true && true = true
@@ -1018,7 +1025,8 @@ mod tests {
         )));
 
         ctx.bind("test_return".to_string(), test_return_function);
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Call with x = 5, should return "too small" directly, skipping the string concatenation
         let small_call = Arc::new(Expr::new(Call(
@@ -1057,7 +1065,8 @@ mod tests {
     async fn test_nested_let_bindings() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // let x = 10 in
         // let y = x * 2 in
@@ -1100,7 +1109,8 @@ mod tests {
         )));
 
         ctx.bind("add".to_string(), add_function);
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Call the function: add(10, 20)
         let call_expr = Arc::new(Expr::new(Call(
@@ -1125,24 +1135,24 @@ mod tests {
         let mut ctx = Context::default();
 
         // Define a Rust UDF that calculates the sum of array elements
-        let sum_function =
-            Value::new(CoreData::Function(FunKind::Udf(UdfKind::Linked(
-                |args| match &args[0].data {
-                    CoreData::Array(elements) => {
-                        let mut sum = 0;
-                        for elem in elements {
-                            if let CoreData::Literal(Literal::Int64(value)) = &elem.data {
-                                sum += value;
-                            }
+        let sum_function = Value::new(CoreData::Function(FunKind::Udf(Udf {
+            func: |args, _catalog| match &args[0].data {
+                CoreData::Array(elements) => {
+                    let mut sum = 0;
+                    for elem in elements {
+                        if let CoreData::Literal(Literal::Int64(value)) = &elem.data {
+                            sum += value;
                         }
-                        Value::new(CoreData::Literal(Literal::Int64(sum)))
                     }
-                    _ => panic!("Expected array argument"),
-                },
-            ))));
+                    Value::new(CoreData::Literal(Literal::Int64(sum)))
+                }
+                _ => panic!("Expected array argument"),
+            },
+        })));
 
         ctx.bind("sum".to_string(), sum_function);
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Call the function: sum([1, 2, 3, 4, 5])
         let call_expr = Arc::new(Expr::new(Call(
@@ -1171,7 +1181,8 @@ mod tests {
     async fn test_map_creation() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a map with key-value pairs: { "a": 1, "b": 2, "c": 3 }
         let map_expr = Arc::new(Expr::new(Map(vec![
@@ -1250,19 +1261,22 @@ mod tests {
         // Add a map lookup function
         ctx.bind(
             "get".to_string(),
-            Value::new(CoreData::Function(FunKind::Udf(UdfKind::Linked(|args| {
-                if args.len() != 2 {
-                    panic!("get function requires 2 arguments");
-                }
+            Value::new(CoreData::Function(FunKind::Udf(Udf {
+                func: |args, _catalog| {
+                    if args.len() != 2 {
+                        panic!("get function requires 2 arguments");
+                    }
 
-                match &args[0].data {
-                    CoreData::Map(map) => map.get(&args[1]),
-                    _ => panic!("First argument must be a map"),
-                }
-            })))),
+                    match &args[0].data {
+                        CoreData::Map(map) => map.get(&args[1]),
+                        _ => panic!("First argument must be a map"),
+                    }
+                },
+            }))),
         );
 
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a nested map:
         // {
@@ -1372,7 +1386,8 @@ mod tests {
         )));
 
         ctx.bind("factorial".to_string(), factorial_function);
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a program that:
         // 1. Defines variables for different values
@@ -1411,7 +1426,8 @@ mod tests {
     async fn test_array_indexing() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create an array [10, 20, 30, 40, 50]
         let array_expr = Arc::new(Expr::new(CoreVal(array_val(vec![
@@ -1454,7 +1470,8 @@ mod tests {
     async fn test_tuple_indexing() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a tuple (10, "hello", true)
         let tuple_expr = Arc::new(Expr::new(CoreVal(Value::new(CoreData::Tuple(vec![
@@ -1483,7 +1500,8 @@ mod tests {
     async fn test_struct_indexing() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a struct Point { x: 10, y: 20 }
         let struct_expr = Arc::new(Expr::new(CoreVal(struct_val(
@@ -1510,7 +1528,8 @@ mod tests {
     async fn test_map_lookup() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a map with key-value pairs: { "a": 1, "b": 2, "c": 3 }
         // Use a let expression to bind the map and do lookups directly
@@ -1566,7 +1585,8 @@ mod tests {
     async fn test_complex_collection_and_index() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a let expression that binds an array and then accesses it
         // let arr = [10, 20, 30, 40, 50] in
@@ -1612,7 +1632,8 @@ mod tests {
     async fn test_logical_operator_indexing() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a logical operator: LogicalJoin { joinType: "inner", condition: "x = y" } [TableScan("orders"), TableScan("lineitem")]
         let join_op = create_logical_operator(
@@ -1709,7 +1730,8 @@ mod tests {
     async fn test_physical_operator_indexing() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a physical operator: HashJoin { method: "hash", condition: "id = id" } [IndexScan("customers"), ParallelScan("orders")]
         let join_op = create_physical_operator(
@@ -1846,7 +1868,8 @@ mod tests {
         )));
 
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Evaluate the expressions
         let join_type_results =
@@ -1941,7 +1964,8 @@ mod tests {
         )));
 
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Evaluate the expressions
         let method_results =
@@ -1989,7 +2013,8 @@ mod tests {
     async fn test_nested_operator_indexing() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Create a nested operator:
         // Project [col1, col2] (
@@ -2078,7 +2103,8 @@ mod tests {
         ctx.push_scope();
         ctx.bind("inner_var".to_string(), lit_val(int(200)));
 
-        let engine = Engine::new(ctx);
+        let catalog = memory_catalog();
+        let engine = Engine::new(ctx, Arc::new(catalog));
 
         // Reference to a variable in the current (inner) scope
         let inner_ref = Arc::new(Expr::new(Ref("inner_var".to_string())));

--- a/optd/src/dsl/engine/eval/match.rs
+++ b/optd/src/dsl/engine/eval/match.rs
@@ -531,7 +531,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::dsl::analyzer::hir::{LetBinding, UdfKind};
+    use crate::catalog::iceberg::memory_catalog;
+    use crate::dsl::analyzer::hir::{LetBinding, Udf};
     use crate::dsl::engine::Engine;
     use crate::dsl::utils::tests::{
         array_decomp_pattern, array_val, bind_pattern, create_logical_operator,
@@ -556,7 +557,8 @@ mod tests {
     async fn test_simple_literal_patterns() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a match expression: match 42 { 42 => "matched", _ => "not matched" }
         let match_expr = pattern_match_expr(
@@ -584,7 +586,8 @@ mod tests {
     async fn test_bind_pattern_with_nesting() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a match expression:
         // match 42 {
@@ -668,17 +671,18 @@ mod tests {
         let mut ctx = Context::default();
         ctx.bind(
             "length".to_string(),
-            Value::new(CoreData::Function(FunKind::Udf(UdfKind::Linked(
-                |args| match &args[0].data {
+            Value::new(CoreData::Function(FunKind::Udf(Udf {
+                func: |args, _catalog| match &args[0].data {
                     CoreData::Array(elements) => {
                         Value::new(CoreData::Literal(int(elements.len() as i64)))
                     }
                     _ => panic!("Expected array"),
                 },
-            )))),
+            }))),
         );
 
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Evaluate the expression
         let results = evaluate_and_collect(match_expr, engine, harness).await;
@@ -697,7 +701,8 @@ mod tests {
     async fn test_struct_patterns() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a struct value Point { x: 10, y: 20 }
         let struct_expr = Arc::new(Expr::new(CoreVal(struct_val(
@@ -744,7 +749,8 @@ mod tests {
     async fn test_complex_operator_patterns() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a logical operator: LogicalJoin { joinType: "inner", condition: "x = y" } [TableScan("orders"), TableScan("lineitem")]
         let op = Operator {
@@ -923,7 +929,8 @@ mod tests {
         );
 
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Evaluate the expression
         let results = evaluate_and_collect(match_expr, engine, harness).await;
@@ -974,12 +981,14 @@ mod tests {
 
         // Create a to_string function
         let to_string_fn = Arc::new(Expr::new(CoreVal(Value::new(CoreData::Function(
-            FunKind::Udf(UdfKind::Linked(|args| match &args[0].data {
-                CoreData::Literal(lit) => {
-                    Value::new(CoreData::Literal(string(&format!("{:?}", lit))))
-                }
-                _ => Value::new(CoreData::Literal(string("<non-literal>"))),
-            })),
+            FunKind::Udf(Udf {
+                func: |args, _catalog| match &args[0].data {
+                    CoreData::Literal(lit) => {
+                        Value::new(CoreData::Literal(string(&format!("{:?}", lit))))
+                    }
+                    _ => Value::new(CoreData::Literal(string("<non-literal>"))),
+                },
+            }),
         )))));
 
         // Create a match expression to match against the expanded physical operator
@@ -1048,7 +1057,8 @@ mod tests {
         );
 
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Evaluate the expression
         let results = evaluate_and_collect(match_expr, engine, harness).await;
@@ -1083,17 +1093,18 @@ mod tests {
         // Add to_string function to convert numbers to strings
         ctx.bind(
             "to_string".to_string(),
-            Value::new(CoreData::Function(FunKind::Udf(UdfKind::Linked(
-                |args| match &args[0].data {
+            Value::new(CoreData::Function(FunKind::Udf(Udf {
+                func: |args, _catalog| match &args[0].data {
                     CoreData::Literal(Literal::Int64(i)) => {
                         Value::new(CoreData::Literal(string(&i.to_string())))
                     }
                     _ => panic!("Expected integer literal"),
                 },
-            )))),
+            }))),
         );
 
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a struct value Point { x: 30, y: 40 }
         let struct_expr = Arc::new(Expr::new(CoreVal(struct_val(
@@ -1215,18 +1226,19 @@ mod tests {
         // Add to_string function to convert complex values to strings
         ctx.bind(
             "to_string".to_string(),
-            Value::new(CoreData::Function(FunKind::Udf(UdfKind::Linked(
-                |args| match &args[0].data {
+            Value::new(CoreData::Function(FunKind::Udf(Udf {
+                func: |args, _catalog| match &args[0].data {
                     CoreData::Literal(lit) => {
                         Value::new(CoreData::Literal(string(&format!("{:?}", lit))))
                     }
                     CoreData::Array(_) => Value::new(CoreData::Literal(string("<array>"))),
                     _ => Value::new(CoreData::Literal(string("<unknown>"))),
                 },
-            )))),
+            }))),
         );
 
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a deeply nested operator:
         // Project [col1, col2] (
@@ -1473,7 +1485,8 @@ mod tests {
         );
 
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Evaluate the expression
         let results = evaluate_and_collect(match_expr, engine, harness).await;

--- a/optd/src/dsl/engine/eval/operator.rs
+++ b/optd/src/dsl/engine/eval/operator.rs
@@ -131,6 +131,7 @@ impl<O: Clone + Send + 'static> Engine<O> {
 
 #[cfg(test)]
 mod tests {
+    use crate::catalog::iceberg::memory_catalog;
     use crate::dsl::engine::Engine;
     use crate::dsl::{
         analyzer::{
@@ -153,7 +154,8 @@ mod tests {
     async fn test_materialized_logical_operator() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a materialized logical operator expression with nested expressions to evaluate
         let log_op = LogicalOp::logical(Operator {
@@ -226,7 +228,8 @@ mod tests {
     async fn test_unmaterialized_logical_operator() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create an unmaterialized logical operator with a group ID
         let group_id = GroupId(42);
@@ -255,7 +258,8 @@ mod tests {
     async fn test_materialized_physical_operator() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a materialized physical operator expression with nested expressions to evaluate
         let phys_op = PhysicalOp::physical(Operator {
@@ -328,7 +332,8 @@ mod tests {
     async fn test_unmaterialized_physical_operator() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create an unmaterialized physical operator with a goal
         let goal = Goal {
@@ -370,7 +375,8 @@ mod tests {
     async fn test_nested_logical_operators() {
         let harness = TestHarness::new();
         let ctx = Context::default();
-        let engine = Engine::new(ctx);
+        let catalog = Arc::new(memory_catalog());
+        let engine = Engine::new(ctx, catalog);
 
         // Create a Join operator with two Scan operators as children
         let scan1 = Arc::new(Expr::new(CoreVal(create_logical_operator(

--- a/optd/src/dsl/engine/mod.rs
+++ b/optd/src/dsl/engine/mod.rs
@@ -1,6 +1,9 @@
-use crate::dsl::analyzer::{
-    context::Context,
-    hir::{Expr, ExprKind, Goal, GroupId, Value},
+use crate::{
+    catalog::Catalog,
+    dsl::analyzer::{
+        context::Context,
+        hir::{Expr, ExprKind, Goal, GroupId, Value},
+    },
 };
 use std::sync::Arc;
 
@@ -28,15 +31,18 @@ pub enum EngineResponse<O> {
 pub struct Engine<O: Clone + Send + 'static> {
     /// The original HIR context containing all defined expressions and rules.
     pub(crate) context: Context,
+    /// The catalog containing all table metadata and statistics.
+    pub(crate) catalog: Arc<dyn Catalog>,
     /// The continuation to return from the current function scope.
     pub(crate) fun_return: Option<Continuation<Value, EngineResponse<O>>>,
 }
 
 impl<O: Clone + Send + 'static> Engine<O> {
     /// Creates a new engine with the given context and expander.
-    pub fn new(context: Context) -> Self {
+    pub fn new(context: Context, catalog: Arc<dyn Catalog>) -> Self {
         Self {
             context,
+            catalog,
             fun_return: None,
         }
     }
@@ -45,6 +51,7 @@ impl<O: Clone + Send + 'static> Engine<O> {
     pub fn with_new_context(self, context: Context) -> Self {
         Self {
             context,
+            catalog: self.catalog,
             fun_return: self.fun_return,
         }
     }
@@ -53,6 +60,7 @@ impl<O: Clone + Send + 'static> Engine<O> {
     pub fn with_new_return(self, fun_return: Continuation<Value, EngineResponse<O>>) -> Self {
         Self {
             context: self.context,
+            catalog: self.catalog,
             fun_return: Some(fun_return),
         }
     }


### PR DESCRIPTION
## Summary of changes

This PR implements linking of UDFs by passing in a table of function pointers into `compile_hir`.

This PR also adds the `Catalog` field to both the rule engine and the optimizer as a trait object (`Arc<dyn Catalog>`). I strongly considered making this a generic parameter, but the problem with that is then the `C: Catalog` type parameter would need to be added to literally every structures and function, and I that would significantly reduce readability. The performance is essentially negligible because it is unlikely the compiler could make significant optimizations based on the implementation of the `Catalog`.

Ideally I would add tests that test the functionality of the catalog as well but I don't have time (and also I don't have any reason to think that it wouldn't work now). Once I get an interface that the optimizer needs from the catalog from @SarveshOO7 and @yliang412, I can add those tests easily.