### PR TITLE
(feat) Rule Annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,7 @@ dependencies = [
  "futures",
  "iceberg",
  "iceberg-catalog-memory",
+ "once_cell",
  "ordered-float 5.0.0",
  "tempfile",
  "tokio",

--- a/optd/Cargo.toml
+++ b/optd/Cargo.toml
@@ -19,6 +19,7 @@ enum_dispatch = "0.3.13"
 futures = "0.3.31"
 iceberg = { version = "0.4.0", default-features = false }
 iceberg-catalog-memory = "0.4.0"
+once_cell = "1.21.3"
 ordered-float = "5.0.0"
 tempfile = "3.19.1"
 tokio = { version = "1.44.2", features = ["macros", "rt"] }

--- a/optd/src/dsl/analyzer/errors.rs
+++ b/optd/src/dsl/analyzer/errors.rs
@@ -449,16 +449,17 @@ impl Diagnose for Box<AnalyzerError> {
                 actual_signature,
                 unknowns,
             } => {
-                // Assuming these are defined in annotations.rs
                 self.build_single_span_report(
                     span,
                     "Invalid transformation function signature",
                     &format!(
-                        "Found: {}\nExpected a subtype of: {}",
-                        type_display(actual_signature, unknowns),
+                        "Found: '{}'",
+                        type_display(actual_signature, unknowns)
+                    ),
+                    &format!(
+                        "Expected a subtype of: '{}'",
                         type_display(&TRANSFORMATION_SIGNATURE_TYPE, unknowns)
                     ),
-                    "Transformations must match the expected signature pattern",
                 )
             },
             InvalidImplementation {
@@ -470,11 +471,13 @@ impl Diagnose for Box<AnalyzerError> {
                     span,
                     "Invalid implementation function signature",
                     &format!(
-                        "Found: {}\nExpected a subtype of: {}",
-                        type_display(actual_signature, unknowns),
+                        "Found: '{}'",
+                        type_display(actual_signature, unknowns)
+                    ),
+                    &format!(
+                        "Expected a subtype of: '{}'", 
                         type_display(&IMPLEMENTATION_SIGNATURE_TYPE, unknowns)
                     ),
-                    "Implementations must match the expected signature pattern",
                 )
             },
         }

--- a/optd/src/dsl/analyzer/errors.rs
+++ b/optd/src/dsl/analyzer/errors.rs
@@ -1,6 +1,9 @@
 use super::{hir::Identifier, type_checks::registry::Type};
 use crate::dsl::{
-    analyzer::type_checks::converter::type_display,
+    analyzer::{
+        into_hir::annotations::{IMPLEMENTATION_SIGNATURE_TYPE, TRANSFORMATION_SIGNATURE_TYPE},
+        type_checks::converter::type_display,
+    },
     utils::{
         errors::Diagnose,
         span::{Span, Spanned},
@@ -119,6 +122,20 @@ pub enum AnalyzerErrorKind {
         object: Type,
         span: Span,
         field: String,
+        // To be able to call display function of Type.
+        unknowns: HashMap<usize, Type>,
+    },
+
+    InvalidTransformation {
+        span: Span,
+        actual_signature: Type,
+        // To be able to call display function of Type.
+        unknowns: HashMap<usize, Type>,
+    },
+
+    InvalidImplementation {
+        span: Span,
+        actual_signature: Type,
         // To be able to call display function of Type.
         unknowns: HashMap<usize, Type>,
     },
@@ -287,6 +304,32 @@ impl AnalyzerErrorKind {
         }
         .into()
     }
+
+    pub fn new_invalid_transformation(
+        span: &Span,
+        actual_signature: &Type,
+        unknowns: HashMap<usize, Type>,
+    ) -> Box<Self> {
+        Self::InvalidTransformation {
+            span: span.clone(),
+            actual_signature: actual_signature.clone(),
+            unknowns,
+        }
+        .into()
+    }
+
+    pub fn new_invalid_implementation(
+        span: &Span,
+        actual_signature: &Type,
+        unknowns: HashMap<usize, Type>,
+    ) -> Box<Self> {
+        Self::InvalidImplementation {
+            span: span.clone(),
+            actual_signature: actual_signature.clone(),
+            unknowns,
+        }
+        .into()
+    }
 }
 
 impl Diagnose for Box<AnalyzerError> {
@@ -401,6 +444,39 @@ impl Diagnose for Box<AnalyzerError> {
                 "Only functions, maps, and arrays can be called",
             ),
             InvalidFieldAccess { object, span, field, unknowns } => self.build_invalid_field_access_report(object, span, field, unknowns),
+            InvalidTransformation {
+                span,
+                actual_signature,
+                unknowns,
+            } => {
+                // Assuming these are defined in annotations.rs
+                self.build_single_span_report(
+                    span,
+                    "Invalid transformation function signature",
+                    &format!(
+                        "Found: {}\nExpected a subtype of: {}",
+                        type_display(actual_signature, unknowns),
+                        type_display(&TRANSFORMATION_SIGNATURE_TYPE, unknowns)
+                    ),
+                    "Transformations must match the expected signature pattern",
+                )
+            },
+            InvalidImplementation {
+                span,
+                actual_signature,
+                unknowns,
+            } => {
+                self.build_single_span_report(
+                    span,
+                    "Invalid implementation function signature",
+                    &format!(
+                        "Found: {}\nExpected a subtype of: {}",
+                        type_display(actual_signature, unknowns),
+                        type_display(&IMPLEMENTATION_SIGNATURE_TYPE, unknowns)
+                    ),
+                    "Implementations must match the expected signature pattern",
+                )
+            },
         }
     }
 
@@ -424,6 +500,8 @@ impl Diagnose for Box<AnalyzerError> {
             ArgumentNumberMismatch { span, .. } => span,
             InvalidCallReceiver { span, .. } => span,
             InvalidFieldAccess { span, .. } => span,
+            InvalidTransformation { span, .. } => span,
+            InvalidImplementation { span, .. } => span,
         };
 
         (span.src_file.clone(), Source::from(self.src_code.clone()))

--- a/optd/src/dsl/analyzer/into_hir/annotations.rs
+++ b/optd/src/dsl/analyzer/into_hir/annotations.rs
@@ -17,7 +17,7 @@ pub const TRANSFORMATION_ANNOTATION: &str = "transformation";
 pub static IMPLEMENTATION_SIGNATURE_TYPE: Lazy<Type> = Lazy::new(|| {
     use TypeKind::*;
     let params_type = Tuple(vec![
-        Stored(Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+        Stored(Adt(LOGICAL_TYPE.to_string()).into()).into(),
         Adt(PHYSICAL_PROPS.to_string()).into(),
     ])
     .into();
@@ -154,7 +154,7 @@ mod tests {
         // Create an implementation function with optional return type
         let function_type = TypeKind::Closure(
             TypeKind::Tuple(vec![
-                TypeKind::Stored(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+                TypeKind::Stored(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
                 TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
             ])
             .into(),
@@ -194,7 +194,7 @@ mod tests {
         // Create an implementation function that returns PhysicalHashJoin (subtype of Physical)
         let function_type = TypeKind::Closure(
             TypeKind::Tuple(vec![
-                TypeKind::Stored(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+                TypeKind::Stored(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
                 TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
             ])
             .into(),
@@ -238,7 +238,7 @@ mod tests {
         // Create an invalid function type (wrong return type)
         let function_type = TypeKind::Closure(
             TypeKind::Tuple(vec![
-                TypeKind::Stored(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+                TypeKind::Stored(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
                 TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
             ])
             .into(),

--- a/optd/src/dsl/analyzer/into_hir/annotations.rs
+++ b/optd/src/dsl/analyzer/into_hir/annotations.rs
@@ -18,7 +18,7 @@ pub static IMPLEMENTATION_SIGNATURE_TYPE: Lazy<Type> = Lazy::new(|| {
     use TypeKind::*;
     let params_type = Tuple(vec![
         Stored(Adt(LOGICAL_TYPE.to_string()).into()).into(),
-        Adt(PHYSICAL_PROPS.to_string()).into(),
+        Optional(Adt(PHYSICAL_PROPS.to_string()).into()).into(),
     ])
     .into();
     let return_type = Optional(Adt(PHYSICAL_TYPE.to_string()).into()).into();
@@ -155,7 +155,7 @@ mod tests {
         let function_type = TypeKind::Closure(
             TypeKind::Tuple(vec![
                 TypeKind::Stored(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
-                TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
+                TypeKind::Optional(TypeKind::Adt(PHYSICAL_PROPS.to_string()).into()).into(),
             ])
             .into(),
             TypeKind::Optional(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
@@ -195,7 +195,7 @@ mod tests {
         let function_type = TypeKind::Closure(
             TypeKind::Tuple(vec![
                 TypeKind::Stored(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
-                TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
+                TypeKind::Optional(TypeKind::Adt(PHYSICAL_PROPS.to_string()).into()).into(),
             ])
             .into(),
             TypeKind::Adt("PhysicalHashJoin".to_string()).into(),

--- a/optd/src/dsl/analyzer/into_hir/annotations.rs
+++ b/optd/src/dsl/analyzer/into_hir/annotations.rs
@@ -1,0 +1,272 @@
+use crate::dsl::analyzer::errors::AnalyzerErrorKind;
+use crate::dsl::analyzer::type_checks::registry::{
+    LOGICAL_TYPE, PHYSICAL_PROPS, PHYSICAL_TYPE, Type, TypeKind, TypeRegistry,
+};
+use crate::dsl::utils::span::Span;
+use once_cell::sync::Lazy;
+
+pub static TRANSFORMATION_SIGNATURE_TYPE: Lazy<Type> = Lazy::new(|| {
+    use TypeKind::*;
+    let param_type = Stored(Adt(LOGICAL_TYPE.to_string()).into()).into();
+    let return_type = Optional(Adt(LOGICAL_TYPE.to_string()).into()).into();
+    Closure(param_type, return_type).into()
+});
+
+pub const TRANSFORMATION_ANNOTATION: &str = "transformation";
+
+pub static IMPLEMENTATION_SIGNATURE_TYPE: Lazy<Type> = Lazy::new(|| {
+    use TypeKind::*;
+    let params_type = Tuple(vec![
+        Stored(Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+        Adt(PHYSICAL_PROPS.to_string()).into(),
+    ])
+    .into();
+    let return_type = Optional(Adt(PHYSICAL_TYPE.to_string()).into()).into();
+    Closure(params_type, return_type).into()
+});
+
+pub const IMPLEMENTATION_ANNOTATION: &str = "implementation";
+
+/// Validates that a function's type matches the expected signature for a given annotation
+///
+/// # Arguments
+///
+/// * `annotation` - The annotation to validate
+/// * `function_type` - The actual type of the function
+/// * `function_span` - The span where the function is defined
+/// * `registry` - The type registry for type checking
+///
+/// # Returns
+///
+/// `Ok(())` if the function type is valid for the annotation, or an error if validation fails
+pub(super) fn validate_annotation(
+    annotation: &str,
+    function_type: &Type,
+    function_span: &Span,
+    registry: &mut TypeRegistry,
+) -> Result<(), Box<AnalyzerErrorKind>> {
+    match annotation {
+        TRANSFORMATION_ANNOTATION => {
+            if !registry.is_subtype(function_type, &TRANSFORMATION_SIGNATURE_TYPE) {
+                return Err(AnalyzerErrorKind::new_invalid_transformation(
+                    function_span,
+                    function_type,
+                    registry.resolved_unknown.clone(),
+                ));
+            }
+        }
+        IMPLEMENTATION_ANNOTATION => {
+            if !registry.is_subtype(function_type, &IMPLEMENTATION_SIGNATURE_TYPE) {
+                return Err(AnalyzerErrorKind::new_invalid_implementation(
+                    function_span,
+                    function_type,
+                    registry.resolved_unknown.clone(),
+                ));
+            }
+        }
+        _ => {
+            // Unknown annotations are ignored for now.
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dsl::{
+        analyzer::type_checks::registry::{
+            TypeRegistry,
+            type_registry_tests::{create_product_adt, create_sum_adt, create_test_span},
+        },
+        parser::ast::Type as AstType,
+    };
+
+    #[test]
+    fn test_validate_transformation_annotation_with_optional_return() {
+        let mut registry = TypeRegistry::new();
+
+        // Create a transformation function with optional return type
+        let function_type = TypeKind::Closure(
+            TypeKind::Stored(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
+            TypeKind::Optional(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
+        )
+        .into();
+
+        let result = validate_annotation(
+            TRANSFORMATION_ANNOTATION,
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_transformation_annotation_with_specialized_return() {
+        let mut registry = TypeRegistry::new();
+
+        // Create LogicalScan as a subtype of Logical
+        let logical_scan = create_product_adt("LogicalScan", vec![("table", AstType::String)]);
+        let logical_enum = create_sum_adt(LOGICAL_TYPE, vec![logical_scan]);
+        registry.register_adt(&logical_enum).unwrap();
+
+        // Create a transformation function that returns LogicalScan (subtype of Logical)
+        let function_type = TypeKind::Closure(
+            TypeKind::Stored(TypeKind::Adt(LOGICAL_TYPE.to_string()).into()).into(),
+            TypeKind::Adt("LogicalScan".to_string()).into(),
+        )
+        .into();
+
+        let result = validate_annotation(
+            TRANSFORMATION_ANNOTATION,
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_transformation_annotation_failure() {
+        let mut registry = TypeRegistry::new();
+
+        // Create an invalid function type (wrong parameter type)
+        let function_type = TypeKind::Closure(
+            TypeKind::I64.into(),
+            TypeKind::Adt(LOGICAL_TYPE.to_string()).into(),
+        )
+        .into();
+
+        let result = validate_annotation(
+            TRANSFORMATION_ANNOTATION,
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_implementation_annotation_with_optional_return() {
+        let mut registry = TypeRegistry::new();
+
+        // Create an implementation function with optional return type
+        let function_type = TypeKind::Closure(
+            TypeKind::Tuple(vec![
+                TypeKind::Stored(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+                TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
+            ])
+            .into(),
+            TypeKind::Optional(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+        )
+        .into();
+
+        let result = validate_annotation(
+            IMPLEMENTATION_ANNOTATION,
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_implementation_annotation_with_specialized_return() {
+        let mut registry = TypeRegistry::new();
+
+        // Create PhysicalHashJoin as a subtype of Physical
+        let physical_hash_join = create_product_adt(
+            "PhysicalHashJoin",
+            vec![
+                ("algorithm", AstType::String),
+                ("left", AstType::Identifier(PHYSICAL_TYPE.to_string())),
+                ("right", AstType::Identifier(PHYSICAL_TYPE.to_string())),
+            ],
+        );
+        let physical_enum = create_sum_adt(PHYSICAL_TYPE, vec![physical_hash_join]);
+        registry.register_adt(&physical_enum).unwrap();
+
+        // Create PhysicalProperties
+        let physical_props = create_product_adt(PHYSICAL_PROPS, vec![("cost", AstType::Int64)]);
+        registry.register_adt(&physical_props).unwrap();
+
+        // Create an implementation function that returns PhysicalHashJoin (subtype of Physical)
+        let function_type = TypeKind::Closure(
+            TypeKind::Tuple(vec![
+                TypeKind::Stored(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+                TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
+            ])
+            .into(),
+            TypeKind::Adt("PhysicalHashJoin".to_string()).into(),
+        )
+        .into();
+
+        let result = validate_annotation(
+            IMPLEMENTATION_ANNOTATION,
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_implementation_annotation_failure_wrong_params() {
+        let mut registry = TypeRegistry::new();
+
+        // Create an invalid function type (wrong parameter types)
+        let function_type = TypeKind::Closure(
+            TypeKind::I64.into(), // Wrong parameter type
+            TypeKind::Adt(PHYSICAL_TYPE.to_string()).into(),
+        )
+        .into();
+
+        let result = validate_annotation(
+            IMPLEMENTATION_ANNOTATION,
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_implementation_annotation_failure_wrong_return() {
+        let mut registry = TypeRegistry::new();
+
+        // Create an invalid function type (wrong return type)
+        let function_type = TypeKind::Closure(
+            TypeKind::Tuple(vec![
+                TypeKind::Stored(TypeKind::Adt(PHYSICAL_TYPE.to_string()).into()).into(),
+                TypeKind::Adt(PHYSICAL_PROPS.to_string()).into(),
+            ])
+            .into(),
+            TypeKind::I64.into(), // Wrong return type
+        )
+        .into();
+
+        let result = validate_annotation(
+            IMPLEMENTATION_ANNOTATION,
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_unknown_annotation() {
+        let mut registry = TypeRegistry::new();
+        let function_type = TypeKind::I64.into();
+
+        // Unknown annotations should always be valid
+        let result = validate_annotation(
+            "unknown_annotation",
+            &function_type,
+            &create_test_span(),
+            &mut registry,
+        );
+        assert!(result.is_ok());
+    }
+}

--- a/optd/src/dsl/analyzer/into_hir/mod.rs
+++ b/optd/src/dsl/analyzer/into_hir/mod.rs
@@ -7,23 +7,32 @@
 //! 1. Removing type annotations from expressions and patterns
 //! 2. Converting struct expressions to operator expressions where appropriate
 //! 3. Transforming field access expressions into indexing operations
+//! 4. Validating function annotations to ensure they match expected signatures
 //!
 //! # Structure
 //!
 //! The module is organized into several submodules:
 //!
+//! - `annotations`: Annotation definitions and validation logic
 //! - `converter`: Main conversion logic for expressions and patterns
 //! - `operators`: Specialized logic for transforming structs into logical/physical operators
 //! - `field_indexing`: Utilities for calculating proper field indices, accounting for operator structures
+//!
+//! # Error Handling
+//!
+//! The conversion process returns a Result type to handle validation errors,
+//! particularly for function annotations that don't match their expected signatures.
 
-use converter::convert_expr;
-
+use super::errors::AnalyzerErrorKind;
 use crate::dsl::analyzer::{
     context::Context,
     hir::{CoreData, FunKind, HIR, TypedSpan, Value},
     type_checks::registry::TypeRegistry,
 };
+use annotations::validate_annotation;
+use converter::convert_expr;
 
+pub(crate) mod annotations;
 mod converter;
 mod field_indexing;
 mod operators;
@@ -31,17 +40,29 @@ mod operators;
 /// Converts a typed HIR into an untyped HIR by removing all type annotations
 ///
 /// This function takes a HIR with type information and produces a HIR without type information,
-/// converting all expressions and patterns in the process.
+/// converting all expressions and patterns in the process. It also validates function annotations
+/// to ensure they match the expected signatures.
 ///
 /// # Arguments
 ///
-/// * `hir` - The typed HIR to convert
+/// * `hir_typedspan` - The typed HIR to convert
 /// * `registry` - The type registry containing type information
 ///
 /// # Returns
 ///
-/// A new HIR instance without type annotations
-pub fn into_hir(hir_typedspan: HIR<TypedSpan>, registry: &TypeRegistry) -> HIR {
+/// A Result containing either:
+/// - A new HIR instance without type annotations
+/// - An AnalyzerError if annotation validation fails
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - A function with a `transformation` annotation doesn't match the expected signature: `Logical* -> Logical`
+/// - A function with an `implementation` annotation doesn't match the expected signature: `Physical* -> (PhysicalProperties -> Physical)`
+pub fn into_hir(
+    hir_typedspan: HIR<TypedSpan>,
+    registry: &mut TypeRegistry,
+) -> Result<HIR, Box<AnalyzerErrorKind>> {
     use CoreData::*;
     use FunKind::*;
 
@@ -49,6 +70,13 @@ pub fn into_hir(hir_typedspan: HIR<TypedSpan>, registry: &TypeRegistry) -> HIR {
 
     // Convert all function bindings from the original context.
     for (name, fun) in hir_typedspan.context.get_all_bindings() {
+        // Validate annotations if they exist.
+        if let Some(annotations) = hir_typedspan.annotations.get(name) {
+            annotations.iter().try_for_each(|annotation| {
+                validate_annotation(annotation, &fun.metadata.ty, &fun.metadata.span, registry)
+            })?;
+        }
+
         let converted_fun = match &fun.data {
             Function(Closure(args, body)) => Closure(args.clone(), convert_expr(body, registry)),
             Function(Udf(udf)) => Udf(udf.clone()),
@@ -61,8 +89,8 @@ pub fn into_hir(hir_typedspan: HIR<TypedSpan>, registry: &TypeRegistry) -> HIR {
     // Push the context scope of the module, as we have processed all functions.
     context.push_scope();
 
-    HIR {
+    Ok(HIR {
         context,
         annotations: hir_typedspan.annotations,
-    }
+    })
 }

--- a/optd/src/dsl/analyzer/type_checks/subtype.rs
+++ b/optd/src/dsl/analyzer/type_checks/subtype.rs
@@ -60,7 +60,7 @@ impl TypeRegistry {
 
     /// Simple wrapper for is_subtype_infer that ignores the has_changed parameter.
     /// Useful for testing and cases where tracking changes isn't needed.
-    pub(super) fn is_subtype(&mut self, child: &Type, parent: &Type) -> bool {
+    pub(crate) fn is_subtype(&mut self, child: &Type, parent: &Type) -> bool {
         let mut has_changed = false;
         self.is_subtype_infer(child, parent, &mut has_changed)
     }

--- a/optd/src/dsl/compile.rs
+++ b/optd/src/dsl/compile.rs
@@ -239,5 +239,7 @@ pub fn infer(
 
     // Step 4: Transform HIR
     // After type inference, transform the HIR into its final form with complete type information.
-    Ok(into_hir(hir, registry))
+    into_hir(hir, registry).map_err(|err_kind| {
+        CompileError::AnalyzerError(AnalyzerError::new(source.to_string(), *err_kind))
+    })
 }

--- a/optd/src/dsl/examples/higher_order.opt
+++ b/optd/src/dsl/examples/higher_order.opt
@@ -61,7 +61,11 @@ fn constant_folder(): Logical -> Logical =
 
 fn arrays(a: [Binary]) = none
 
-fn main(): Logical = 
+[implementation]
+fn (phys: Physical*) implementation(prop: PhysicalProperties) = none
+
+[transformation]
+fn main(log: Logical): Logical = 
     let
         a = Number(10),
         b = Number(20),

--- a/optd/src/dsl/examples/higher_order.opt
+++ b/optd/src/dsl/examples/higher_order.opt
@@ -62,7 +62,7 @@ fn constant_folder(): Logical -> Logical =
 fn arrays(a: [Binary]) = none
 
 [implementation]
-fn (phys: Physical*) implementation(prop: PhysicalProperties) = none
+fn (phys: Physical*) implementation(prop: PhysicalProperties) = 5
 
 [transformation]
 fn main(log: Logical): Logical = 


### PR DESCRIPTION
### About

Checks the validity of `transformation` and `implementation` annotations during the `into_hir` stage.
Tackles half of #86 , as the `Rulebook` part needs rather be done in the `core` directory. Since the issue targeted the DSL particularly, it is thereby solved.

Transformations must inherit: `Logical* -> Logical?`
Implementations must inherit: `(Logical*, PhysicalProperties) -> Physical?`

### Example

![image](https://github.com/user-attachments/assets/29e2109c-069d-4926-9d36-43c4acaa6a06)

