### PR TITLE
(feat) Array Decomposition Type Inference

### DIFF
--- a/optd/src/dsl/analyzer/errors.rs
+++ b/optd/src/dsl/analyzer/errors.rs
@@ -139,6 +139,14 @@ pub enum AnalyzerErrorKind {
         // To be able to call display function of Type.
         unknowns: HashMap<usize, Type>,
     },
+
+    InvalidArrayDecomposition {
+        scrutinee_span: Span,
+        pattern_span: Span,
+        scrutinee_type: Type,
+        // To be able to call display function of Type
+        unknowns: HashMap<usize, Type>,
+    },
 }
 
 impl AnalyzerErrorKind {
@@ -330,6 +338,22 @@ impl AnalyzerErrorKind {
         }
         .into()
     }
+
+    // New constructor for array decomposition errors
+    pub fn new_invalid_array_decomposition(
+        scrutinee_span: &Span,
+        pattern_span: &Span,
+        scrutinee_type: &Type,
+        unknowns: HashMap<usize, Type>,
+    ) -> Box<Self> {
+        Self::InvalidArrayDecomposition {
+            scrutinee_span: scrutinee_span.clone(),
+            pattern_span: pattern_span.clone(),
+            scrutinee_type: scrutinee_type.clone(),
+            unknowns,
+        }
+        .into()
+    }
 }
 
 impl Diagnose for Box<AnalyzerError> {
@@ -480,6 +504,13 @@ impl Diagnose for Box<AnalyzerError> {
                     ),
                 )
             },
+            // Handler for the new InvalidArrayDecomposition error
+            InvalidArrayDecomposition {
+                scrutinee_span,
+                pattern_span,
+                scrutinee_type,
+                unknowns,
+            } => self.build_array_decomp_error_report(scrutinee_span, pattern_span, scrutinee_type, unknowns),
         }
     }
 
@@ -505,6 +536,7 @@ impl Diagnose for Box<AnalyzerError> {
             InvalidFieldAccess { span, .. } => span,
             InvalidTransformation { span, .. } => span,
             InvalidImplementation { span, .. } => span,
+            InvalidArrayDecomposition { pattern_span, .. } => pattern_span, // Use pattern span as primary
         };
 
         (span.src_file.clone(), Source::from(self.src_code.clone()))
@@ -620,6 +652,37 @@ impl AnalyzerError {
 
         report
             .with_help("Check for typos in the field name or ensure you're accessing the right type of object")
+            .finish()
+    }
+
+    /// Helper method to build a report for array decomposition errors
+    fn build_array_decomp_error_report(
+        &self,
+        scrutinee_span: &Span,
+        pattern_span: &Span,
+        scrutinee_type: &Type,
+        unknowns: &HashMap<usize, Type>,
+    ) -> Report<Span> {
+        let mut report = Report::build(ReportKind::Error, pattern_span.clone())
+            .with_message("Cannot decompose further here");
+
+        report = report
+            .with_label(
+                Label::new(pattern_span.clone())
+                    .with_message("Array decomposition pattern used here")
+                    .with_color(Color::Red),
+            )
+            .with_label(
+                Label::new(scrutinee_span.clone())
+                    .with_message(format!(
+                        "Expression contains type '{}', which is not an array",
+                        type_display(scrutinee_type, unknowns)
+                    ))
+                    .with_color(Color::Blue),
+            );
+
+        report
+            .with_help("Array decomposition patterns can only be used with array types")
             .finish()
     }
 

--- a/optd/src/dsl/analyzer/from_ast/expr.rs
+++ b/optd/src/dsl/analyzer/from_ast/expr.rs
@@ -274,7 +274,7 @@ impl ASTConverter {
         generics: &HashSet<Identifier>,
     ) -> Result<ExprKind<TypedSpan>, Box<AnalyzerErrorKind>> {
         let hir_scrutinee = self.convert_expr(scrutinee, generics)?;
-        let hir_arms = self.convert_match_arms(&hir_scrutinee.metadata.ty, arms, generics)?;
+        let hir_arms = self.convert_match_arms(arms, generics)?;
 
         Ok(PatternMatch(hir_scrutinee.into(), hir_arms))
     }

--- a/optd/src/dsl/analyzer/from_ast/pattern.rs
+++ b/optd/src/dsl/analyzer/from_ast/pattern.rs
@@ -6,7 +6,7 @@
 use super::converter::ASTConverter;
 use crate::dsl::analyzer::errors::AnalyzerErrorKind;
 use crate::dsl::analyzer::hir::{Identifier, MatchArm, Pattern, PatternKind, TypedSpan};
-use crate::dsl::analyzer::type_checks::registry::{Type, TypeKind};
+use crate::dsl::analyzer::type_checks::registry::TypeKind;
 use crate::dsl::parser::ast::{self, Pattern as AstPattern};
 use crate::dsl::utils::span::Spanned;
 use std::collections::HashSet;
@@ -19,13 +19,12 @@ impl ASTConverter {
     /// the patterns and expressions in match arms.
     pub(super) fn convert_match_arms(
         &mut self,
-        scrutinee_ty: &Type,
         arms: &[Spanned<ast::MatchArm>],
         generics: &HashSet<Identifier>,
     ) -> Result<Vec<MatchArm<TypedSpan>>, Box<AnalyzerErrorKind>> {
         arms.iter()
             .map(|arm| {
-                let pattern = self.convert_pattern(&arm.pattern, &Some(scrutinee_ty.clone()))?;
+                let pattern = self.convert_pattern(&arm.pattern)?;
                 let expr = self.convert_expr(&arm.expr, generics)?;
 
                 Ok(MatchArm {
@@ -38,70 +37,53 @@ impl ASTConverter {
 
     /// Converts an AST pattern to an HIR pattern.
     ///
-    /// Each pattern kind determines its own specific type, which will be used
-    /// during pattern matching and constraint solving.
+    /// We must be very conservative in our type initialization here, as it requires
+    /// more information about the scrutinee (e.g. $, *, Array, etc.).
     fn convert_pattern(
         &mut self,
         spanned_pattern: &Spanned<AstPattern>,
-        parent_ty: &Option<Type>,
     ) -> Result<Pattern<TypedSpan>, Box<AnalyzerErrorKind>> {
         use TypeKind::*;
 
         let span = spanned_pattern.span.clone();
+        let mut ty = self.registry.new_unknown_asc().into();
 
-        let (kind, ty) = match &*spanned_pattern.value {
+        let kind = match &*spanned_pattern.value {
             AstPattern::Error => panic!("AST should no longer contain errors"),
             AstPattern::Bind(name, inner_pattern) => {
-                let hir_inner = self.convert_pattern(inner_pattern, parent_ty)?;
+                let hir_inner = self.convert_pattern(inner_pattern)?;
+                ty = hir_inner.metadata.ty.clone();
 
-                (
-                    PatternKind::Bind(*name.value.clone(), hir_inner.clone().into()),
-                    hir_inner.metadata.ty,
-                )
+                PatternKind::Bind(*name.value.clone(), hir_inner.clone().into())
             }
             AstPattern::Constructor(name, args) => {
                 self.validate_constructor(name, &span, args.len())?;
 
                 let hir_args = args
                     .iter()
-                    .enumerate()
-                    .map(|(idx, arg)| {
-                        self.convert_pattern(
-                            arg,
-                            &self
-                                .registry
-                                .get_product_field_type_by_index(name, idx)
-                                .unwrap()
-                                .into(),
-                        )
-                    })
+                    .map(|arg| self.convert_pattern(arg))
                     .collect::<Result<Vec<_>, _>>()?;
+                ty = Adt(*name.value.clone()).into();
 
-                (
-                    PatternKind::Struct(*name.value.clone(), hir_args),
-                    Adt(*name.value.clone()).into(),
-                )
+                PatternKind::Struct(*name.value.clone(), hir_args)
             }
             AstPattern::Literal(lit) => {
                 let (hir_lit, hir_ty) = self.convert_literal(lit);
+                ty = hir_ty;
 
-                (PatternKind::Literal(hir_lit), hir_ty)
+                PatternKind::Literal(hir_lit)
             }
-            AstPattern::Wildcard => (
-                PatternKind::Wildcard,
-                parent_ty
-                    .clone()
-                    .unwrap_or_else(|| self.registry.new_unknown_asc().into()),
-            ),
-            AstPattern::EmptyArray => (PatternKind::EmptyArray, Array(Nothing.into()).into()),
+            AstPattern::Wildcard => PatternKind::Wildcard,
+            AstPattern::EmptyArray => {
+                ty = Array(Nothing.into()).into();
+                PatternKind::EmptyArray
+            }
             AstPattern::ArrayDecomp(head, tail) => {
-                let hir_head = self.convert_pattern(head, &Option::None)?;
-                let hir_tail = self.convert_pattern(tail, parent_ty)?;
+                let hir_head = self.convert_pattern(head)?;
+                let hir_tail = self.convert_pattern(tail)?;
+                ty = Array(hir_head.metadata.ty.clone()).into();
 
-                (
-                    PatternKind::ArrayDecomp(hir_head.clone().into(), hir_tail.into()),
-                    Array(self.registry.new_unknown_asc().into()).into(),
-                )
+                PatternKind::ArrayDecomp(hir_head.clone().into(), hir_tail.into())
             }
         };
 
@@ -113,7 +95,6 @@ impl ASTConverter {
 mod pattern_tests {
     use crate::dsl::analyzer::from_ast::converter::ASTConverter;
     use crate::dsl::analyzer::hir::{Literal, PatternKind};
-    use crate::dsl::analyzer::type_checks::registry::TypeKind;
     use crate::dsl::parser::ast::{self, Field, Literal as AstLiteral, Pattern as AstPattern};
     use crate::dsl::utils::span::{Span, Spanned};
     use std::collections::HashSet;
@@ -181,12 +162,9 @@ mod pattern_tests {
 
         let arms = vec![arm1, arm2, arm3];
 
-        // Create some arbitrary scrutinee type
-        let scrutinee_ty = TypeKind::I64.into();
-
         // Convert the match arms
         let result = converter
-            .convert_match_arms(&scrutinee_ty, &arms, &HashSet::new())
+            .convert_match_arms(&arms, &HashSet::new())
             .expect("Failed to convert match arms");
 
         // Check the converted result
@@ -222,7 +200,7 @@ mod pattern_tests {
         let invalid_arm = create_match_arm(invalid_pattern, invalid_expr);
 
         let invalid_arms = vec![invalid_arm];
-        let result = converter.convert_match_arms(&scrutinee_ty, &invalid_arms, &HashSet::new());
+        let result = converter.convert_match_arms(&invalid_arms, &HashSet::new());
         assert!(
             result.is_err(),
             "Expected error for undefined type in match arm"
@@ -243,7 +221,7 @@ mod pattern_tests {
         // Test literal pattern
         let int_pattern = spanned(AstPattern::Literal(AstLiteral::Int64(42)));
         let result = converter
-            .convert_pattern(&int_pattern, &None)
+            .convert_pattern(&int_pattern)
             .expect("Literal pattern conversion should succeed");
 
         match &result.kind {
@@ -254,7 +232,7 @@ mod pattern_tests {
         // Test wildcard pattern
         let wildcard_pattern = spanned(AstPattern::Wildcard);
         let result = converter
-            .convert_pattern(&wildcard_pattern, &None)
+            .convert_pattern(&wildcard_pattern)
             .expect("Wildcard pattern conversion should succeed");
 
         match &result.kind {
@@ -267,7 +245,7 @@ mod pattern_tests {
         let bind_pattern = spanned(AstPattern::Bind(spanned("x".to_string()), inner));
 
         let result = converter
-            .convert_pattern(&bind_pattern, &None)
+            .convert_pattern(&bind_pattern)
             .expect("Binding pattern conversion should succeed");
 
         match &result.kind {
@@ -282,7 +260,7 @@ mod pattern_tests {
         ));
 
         let result = converter
-            .convert_pattern(&constructor_pattern, &None)
+            .convert_pattern(&constructor_pattern)
             .expect("Constructor pattern conversion should succeed");
 
         match &result.kind {
@@ -296,7 +274,7 @@ mod pattern_tests {
         // Test array patterns
         let empty_array_pattern = spanned(AstPattern::EmptyArray);
         let result = converter
-            .convert_pattern(&empty_array_pattern, &None)
+            .convert_pattern(&empty_array_pattern)
             .expect("Empty array pattern conversion should succeed");
 
         match &result.kind {
@@ -309,7 +287,7 @@ mod pattern_tests {
             spanned("UnknownType".to_string()),
             vec![spanned(AstPattern::Wildcard), spanned(AstPattern::Wildcard)],
         ));
-        let result = converter.convert_pattern(&unknown_constructor, &None);
+        let result = converter.convert_pattern(&unknown_constructor);
         assert!(
             result.is_err(),
             "Expected error for unknown type in constructor pattern"
@@ -333,7 +311,7 @@ mod pattern_tests {
         let array_decomp = spanned(AstPattern::ArrayDecomp(head, tail));
 
         let result = converter
-            .convert_pattern(&array_decomp, &None)
+            .convert_pattern(&array_decomp)
             .expect("Array decomposition pattern conversion should succeed");
 
         match &result.kind {
@@ -374,7 +352,7 @@ mod pattern_tests {
             spanned("Shape".to_string()),
             vec![spanned(AstPattern::Wildcard)],
         ));
-        assert!(converter.convert_pattern(&shape_pattern, &None).is_ok());
+        assert!(converter.convert_pattern(&shape_pattern).is_ok());
 
         // Test nested constructor patterns (all valid)
         let circle_inner = spanned(AstPattern::Constructor(
@@ -387,7 +365,7 @@ mod pattern_tests {
             vec![circle_inner],
         ));
 
-        let result = converter.convert_pattern(&nested_pattern, &None);
+        let result = converter.convert_pattern(&nested_pattern);
         assert!(
             result.is_ok(),
             "Valid nested constructor pattern should succeed"
@@ -404,7 +382,7 @@ mod pattern_tests {
             vec![invalid_inner],
         ));
 
-        let result = converter.convert_pattern(&invalid_nested, &None);
+        let result = converter.convert_pattern(&invalid_nested);
         assert!(
             result.is_err(),
             "Nested pattern with invalid constructor should fail"
@@ -428,7 +406,7 @@ mod pattern_tests {
             vec![spanned(AstPattern::Wildcard), spanned(AstPattern::Wildcard)],
         ));
 
-        let result = converter.convert_pattern(&correct_pattern, &None);
+        let result = converter.convert_pattern(&correct_pattern);
         assert!(
             result.is_ok(),
             "Constructor pattern with correct field count should succeed"
@@ -440,7 +418,7 @@ mod pattern_tests {
             vec![spanned(AstPattern::Wildcard)],
         ));
 
-        let result = converter.convert_pattern(&too_few_args, &None);
+        let result = converter.convert_pattern(&too_few_args);
         assert!(
             result.is_err(),
             "Constructor pattern with too few arguments should fail"
@@ -456,7 +434,7 @@ mod pattern_tests {
             ],
         ));
 
-        let result = converter.convert_pattern(&too_many_args, &None);
+        let result = converter.convert_pattern(&too_many_args);
         assert!(
             result.is_err(),
             "Constructor pattern with too many arguments should fail"

--- a/optd/src/dsl/analyzer/type_checks/generate.rs
+++ b/optd/src/dsl/analyzer/type_checks/generate.rs
@@ -133,29 +133,30 @@ impl TypeRegistry {
         arms: &[MatchArm<TypedSpan>],
         ctx: Context<TypedSpan>,
     ) -> Result<(), Box<AnalyzerErrorKind>> {
-        let mut pattern_types = Vec::with_capacity(arms.len());
         let mut arm_types = Vec::with_capacity(arms.len());
 
         for arm in arms {
-            pattern_types.push(arm.pattern.metadata.clone());
             arm_types.push(arm.expr.metadata.clone());
+
+            self.add_constraint_scrutinee(&scrutinee.metadata, &arm.pattern);
 
             let mut arm_ctx = ctx.clone();
             arm_ctx.push_scope();
 
-            self.generate_pattern(&arm.pattern, &mut arm_ctx)?;
+            Self::generate_pattern(&arm.pattern, &mut arm_ctx)?;
             self.generate_expr(&arm.expr, arm_ctx)?;
         }
 
-        self.add_constraint_subtypes(&scrutinee.metadata.ty, &pattern_types);
         self.add_constraint_subtypes(&expr.metadata.ty, &arm_types);
 
         self.generate_expr(scrutinee, ctx)
     }
 
-    /// Validates pattern bindings, and adds them to the context.
+    /// Adds pattern bindings to the context.
+    ///
+    /// Pattern validity is checked later in the type checker, as it requires
+    /// more information about the scrutinee (e.g. $, *, Array, etc.).
     fn generate_pattern(
-        &mut self,
         pattern: &Pattern<TypedSpan>,
         ctx: &mut Context<TypedSpan>,
     ) -> Result<(), Box<AnalyzerErrorKind>> {
@@ -165,33 +166,17 @@ impl TypeRegistry {
             Bind(name, sub_pattern) => {
                 let dummy = Self::dummy_value(&pattern.metadata.ty, &pattern.metadata.span);
                 ctx.try_bind(name.clone(), dummy)?;
-                self.generate_pattern(sub_pattern, ctx)?;
+                Self::generate_pattern(sub_pattern, ctx)?;
             }
-            Struct(name, field_patterns) => {
+            Struct(_, field_patterns) => {
                 field_patterns
                     .iter()
-                    .enumerate()
-                    .try_for_each(|(i, field_pat)| {
-                        self.add_constraint_subtypes(
-                            &self.get_product_field_type_by_index(name, i).unwrap(),
-                            &[field_pat.metadata.clone()],
-                        );
-                        self.generate_pattern(field_pat, ctx)
-                    })?;
+                    .try_for_each(|field_pat| Self::generate_pattern(field_pat, ctx))?;
             }
             Operator(_) => panic!("Operators may not be in the HIR yet"),
             ArrayDecomp(head, tail) => {
-                if let TypeKind::Array(ty) = &*pattern.metadata.ty {
-                    self.add_constraint_subtypes(ty, &[head.metadata.clone()]);
-                } else {
-                    panic!("Type should be set to array in from_ast");
-                }
-
-                // TODO(#81): Generate some extra list constraint here.
-
-                self.add_constraint_subtypes(&pattern.metadata.ty, &[tail.metadata.clone()]);
-                self.generate_pattern(head, ctx)?;
-                self.generate_pattern(tail, ctx)?;
+                Self::generate_pattern(head, ctx)?;
+                Self::generate_pattern(tail, ctx)?;
             }
             Wildcard | EmptyArray | Literal(_) => {} // Terminal patterns, no action needed.
         }

--- a/optd/src/dsl/analyzer/type_checks/registry.rs
+++ b/optd/src/dsl/analyzer/type_checks/registry.rs
@@ -1,5 +1,5 @@
 use crate::dsl::analyzer::errors::AnalyzerErrorKind;
-use crate::dsl::analyzer::hir::{Identifier, TypedSpan};
+use crate::dsl::analyzer::hir::{Identifier, Pattern, TypedSpan};
 use crate::dsl::parser::ast::{Adt, Field};
 use crate::dsl::utils::span::{OptionalSpanned, Span};
 use Adt::*;
@@ -112,6 +112,18 @@ pub enum Constraint {
         inner: TypedSpan,
         args: Vec<TypedSpan>,
         outer: TypedSpan,
+    },
+
+    /// Pattern match: `scrutinee >: pattern`
+    ///
+    /// This constraint enforces that the type of `scrutinee` is compatible with
+    /// the pattern `pattern`. It does not only check for subtyping, but also
+    /// ensures that the pattern can be destructured from the scrutinee.
+    ///
+    /// (e.g. in the context of list decomposition, * and $ handling, etc.)
+    Scrutinee {
+        scrutinee: TypedSpan,
+        pattern: Pattern<TypedSpan>,
     },
 
     /// Field access: `outer >: inner.field`
@@ -289,8 +301,6 @@ impl TypeRegistry {
 
     /// Adds a subtyping constraint set: `parent >: all children`
     ///
-    /// This constraint enforces that the parent is a supertype of all the children.
-    ///
     /// # Arguments
     ///
     /// * `parent` - The type that must be a supertype of all children
@@ -305,8 +315,6 @@ impl TypeRegistry {
     }
 
     /// Adds an equality constraint: `target_type = other_type`
-    ///
-    /// This constraint enforces that the target_type is equal to other_type.
     ///
     /// # Arguments
     ///
@@ -326,9 +334,6 @@ impl TypeRegistry {
 
     /// Adds a function call constraint: `outer >: inner(args)`
     ///
-    /// This enforces that the function type `inner` can be called with
-    /// the arguments `args`, and that the result type matches `outer`.
-    ///
     /// # Arguments
     ///
     /// * `outer` - The expected return type of the function call
@@ -347,9 +352,24 @@ impl TypeRegistry {
         });
     }
 
-    /// Adds a field access constraint: `outer >: inner.field`
+    /// Adds a pattern match constraint: `scrutinee >: pattern`
     ///
-    /// This enforces that a type has a field with a particular name and type.
+    /// # Arguments
+    ///
+    /// * `scrutinee` - The type of the scrutinee being matched
+    /// * `pattern` - The pattern being matched against the scrutinee
+    pub(super) fn add_constraint_scrutinee(
+        &mut self,
+        scrutinee: &TypedSpan,
+        pattern: &Pattern<TypedSpan>,
+    ) {
+        self.constraints.push(Constraint::Scrutinee {
+            scrutinee: scrutinee.clone(),
+            pattern: pattern.clone(),
+        });
+    }
+
+    /// Adds a field access constraint: `outer >: inner.field`
     ///
     /// # Arguments
     ///

--- a/optd/src/dsl/analyzer/type_checks/solver.rs
+++ b/optd/src/dsl/analyzer/type_checks/solver.rs
@@ -152,10 +152,12 @@ impl TypeRegistry {
                 self.combine_results(param_result, ret_result)
             }
 
+            // Maps are callable with key type for indexing.
             TypeKind::Map(key_type, val_type) => {
                 self.check_indexable(&inner.span, args, key_type, val_type, &outer.ty)
             }
 
+            // Arrays are callable with integer indices.
             TypeKind::Array(elem_type) => {
                 let index_type = TypeKind::I64.into();
                 self.check_indexable(&inner.span, args, &index_type, elem_type, &outer.ty)
@@ -172,6 +174,7 @@ impl TypeRegistry {
         }
     }
 
+    // Helper for array/map indexing operations where lookups might fail.
     fn check_indexable(
         &mut self,
         span: &Span,
@@ -193,19 +196,6 @@ impl TypeRegistry {
             .check_subtype_constraint(&TypedSpan::new(optional_elem_type, span.clone()), outer_ty);
 
         self.combine_results(index_result, elem_result)
-    }
-
-    fn combine_results(
-        &self,
-        result1: ConstraintResult,
-        result2: ConstraintResult,
-    ) -> ConstraintResult {
-        match (result1, result2) {
-            (Ok(changed1), Ok(changed2)) => Ok(changed1 | changed2),
-            (Ok(changed1), Err((err2, changed2))) => Err((err2, changed1 | changed2)),
-            (Err((err1, changed1)), Ok(changed2)) => Err((err1, changed1 | changed2)),
-            (Err((err1, changed1)), Err((_, changed2))) => Err((err1, changed1 | changed2)),
-        }
     }
 
     fn check_field_access_constraint(
@@ -258,58 +248,88 @@ impl TypeRegistry {
         pattern: &Pattern<TypedSpan>,
     ) -> ConstraintResult {
         use PatternKind::*;
+        use TypeKind::*;
 
         let scrutinee_ty = self.resolve_type(&scrutinee.ty);
         if matches!(*scrutinee_ty.value, TypeKind::Nothing) {
-            // TODO: May also throw an error here.
             return Ok(false);
         }
 
         match &pattern.kind {
             Bind(_, sub_pattern) => self.check_pattern_match_constraint(scrutinee, sub_pattern),
+
             Struct(name, field_patterns) => {
-                let field_checks_result = field_patterns.iter().enumerate().try_fold(
-                    false,
-                    |acc_changed, (i, field_pat)| {
+                // Process all field patterns using fold to accumulate all changes and errors.
+                // Using #[allow(clippy::manual_try_fold)] to silence the warning since we specifically
+                // don't want try_fold's early-return behavior.
+                #[allow(clippy::manual_try_fold)]
+                let field_checks_result = field_patterns.iter().enumerate().fold(
+                    Ok(false),
+                    |acc_result, (i, field_pat)| {
                         let field_type = self.get_product_field_type_by_index(name, i).unwrap();
                         let field_scrutinee =
                             TypedSpan::new(field_type, field_pat.metadata.span.clone());
 
-                        self.check_pattern_match_constraint(&field_scrutinee, field_pat)
-                            .map(|changed| acc_changed | changed)
+                        let field_result =
+                            self.check_pattern_match_constraint(&field_scrutinee, field_pat);
+
+                        self.combine_results(acc_result, field_result)
                     },
                 );
 
                 let pattern_check = self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty);
                 self.combine_results(field_checks_result, pattern_check)
             }
+
             Operator(_) => panic!("Operators may not be in the HIR yet"),
+
             ArrayDecomp(head, tail) => {
-                // TODO: What about OPTIONAL???????????
-                let head_check = if let TypeKind::Array(ty) = &*scrutinee_ty {
-                    // We duplicate the span out of lack of any better way to do this for now.
+                let head_check = if let Array(ty) = &*scrutinee_ty.value {
                     let inner_scrutinee = TypedSpan::new(ty.clone(), scrutinee.span.clone());
                     self.check_pattern_match_constraint(&inner_scrutinee, head)
                 } else {
-                    // TODO: Add a special error here.
-                    todo!("Add a special error here: not array!")
+                    return Err((
+                        AnalyzerErrorKind::new_invalid_array_decomposition(
+                            &scrutinee.span,
+                            &pattern.metadata.span,
+                            &scrutinee_ty,
+                            self.resolved_unknown.clone(),
+                        ),
+                        false,
+                    ));
                 };
+
                 let tail_check = self.check_pattern_match_constraint(scrutinee, tail);
                 let inner_check = self.combine_results(head_check, tail_check);
+                let pattern_check = self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty);
 
-                let outer_check = self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty);
-
-                self.combine_results(inner_check, outer_check)
+                self.combine_results(inner_check, pattern_check)
             }
+
             EmptyArray | Literal(_) => {
                 self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty)
             }
+
             Wildcard => {
                 // Here, we just try to enforce the wildcard type to be the same as the scrutinee type.
                 let lhs = self.check_subtype_constraint(scrutinee, &pattern.metadata.ty);
                 let rhs = self.check_subtype_constraint(&pattern.metadata, &scrutinee_ty);
                 self.combine_results(lhs, rhs)
             }
+        }
+    }
+
+    // Combines results while preserving type changes and prioritizing the first error
+    fn combine_results(
+        &self,
+        result1: ConstraintResult,
+        result2: ConstraintResult,
+    ) -> ConstraintResult {
+        match (result1, result2) {
+            (Ok(changed1), Ok(changed2)) => Ok(changed1 | changed2),
+            (Ok(changed1), Err((err2, changed2))) => Err((err2, changed1 | changed2)),
+            (Err((err1, changed1)), Ok(changed2)) => Err((err1, changed1 | changed2)),
+            (Err((err1, changed1)), Err((_, changed2))) => Err((err1, changed1 | changed2)),
         }
     }
 }
@@ -635,6 +655,229 @@ mod tests {
         assert!(
             result.is_ok(),
             "Valid complex ADT hierarchy program failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_list_pattern_matching() {
+        let source = r#"
+        data Foo = 
+            | Add(left: Foo, right: Foo)
+            | List(bla: [Foo])
+            \ Const(val: I64)
+            
+        fn (log: Foo) fold = x -> x
+        
+        fn arr_as_function(other: Foo, idx: I64, closure: I64 -> Foo?) = closure(idx)
+        
+        fn main(log: Foo): Foo? = match log
+            | Add(Add(_,_), right: Const(val)) -> {
+                let closure = x -> right in
+                closure(5)
+            }
+            | fooo -> arr_as_function(fooo, 0, [log])
+            | List(bla) -> match bla
+                | vla -> vla(0)
+                \ [] -> none
+            | Add(left, right) -> left
+            \ _ -> fail("brru")
+            
+        fn (log: [Foo]) vla: [Foo] = match log
+            \ [Const(5) .. [List([Const(5) .. _]) .. v]] -> v
+        "#;
+
+        let result = run_type_inference(source, "list_pattern_matching.opt");
+        assert!(
+            result.is_ok(),
+            "Valid list pattern matching program failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_complex_list_decomposition() {
+        let source = r#"
+        data Foo = 
+            | Add(left: Foo, right: Foo)
+            | List(bla: [Foo])
+            \ Const(val: I64)
+            
+        // Test different array decomposition patterns
+        fn process_array(arr: [Foo]): I64 = match arr
+            | [] -> 0
+            | [x .. _] -> match x
+                | Const(val) -> val
+                \ _ -> 1
+            | [x .. [y .. _]] -> match x
+                | Const(a) -> a
+                \ _ -> 2
+            | [Const(a) .. rest] -> a + process_array(rest)
+            \ _ -> -1
+            
+        fn main(): I64 = 
+            let array = [Const(1), Const(2), Const(3), Const(4)] in
+            process_array(array)
+        "#;
+
+        let result = run_type_inference(source, "complex_list_decomposition.opt");
+        assert!(
+            result.is_ok(),
+            "Valid complex list decomposition program failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_nested_list_patterns() {
+        let source = r#"
+        data Foo = 
+            | Add(left: Foo, right: Foo)
+            | List(bla: [Foo])
+            \ Const(val: I64)
+            
+        fn process_nested(nested: [[Foo]]): I64 = match nested
+            | [] -> 0
+            | [[] .. _] -> 1
+            | [[Const(x) .. _] .. rest] -> x + process_nested(rest)
+            | [[Add(Const(a), Const(b)) .. _] .. rest] -> a + b + process_nested(rest)
+            \ _ -> -1
+            
+        fn main(): I64 = process_nested([[Add(Const(2), Const(3))]])
+        "#;
+
+        let result = run_type_inference(source, "nested_list_patterns.opt");
+        assert!(
+            result.is_ok(),
+            "Valid nested list patterns program failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_list_pattern_type_mismatch() {
+        let source = r#"
+        data Foo = 
+        | Add(left: Foo, right: Foo)
+        | List(bla: [Foo])
+        \ Const(val: I64)
+    
+        data Bar(value: String)
+        
+        // This should fail because we're trying to match a list of Bar 
+        // with a pattern expecting a list of Foo
+        fn process_incorrect_types(bars: [Bar]): I64 = match bars
+            | [Const(5) .. _] -> 1  // Type mismatch: Bar is not compatible with Const
+            \ _ -> 0
+            
+        fn main(): I64 = 
+            let bars = [Bar("test")] in
+            process_incorrect_types(bars)
+        "#;
+
+        let result = run_type_inference(source, "list_pattern_type_mismatch.opt");
+        assert!(
+            result.is_err(),
+            "Type mismatch in list pattern should have failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_array_decomp_on_non_array() {
+        let source = r#"
+        data Foo = 
+            | Add(left: Foo, right: Foo)
+            | List(bla: [Foo])
+            \ Const(val: I64)
+        
+        // This should fail because we're using array decomposition on a non-array type
+        fn process_non_array(foo: Foo): I64 = match foo
+            | [head .. tail] -> 1  // Error: Foo is not an array type
+            \ _ -> 0
+            
+        fn main(): I64 = 
+            let foo = Const(42) in
+            process_non_array(foo)
+        "#;
+
+        let result = run_type_inference(source, "array_decomp_on_non_array.opt");
+        assert!(
+            result.is_err(),
+            "Array decomposition on non-array type should have failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_inconsistent_list_pattern() {
+        let source = r#"
+        data Foo = 
+        | Add(left: Foo, right: Foo)
+        \ Const(val: I64)
+    
+        // This should fail because the pattern is inconsistent in its typing
+        fn process_mixed_list(mixed: [I64]): I64 = match mixed
+            | [x .. [Const(y) .. rest]] -> x + y  // Error: Const is Foo type but we're matching against [I64]
+            \ _ -> 0
+            
+        fn main(): I64 = 
+            let nums = [1, 2, 3] in
+            process_mixed_list(nums)
+        "#;
+
+        let result = run_type_inference(source, "inconsistent_list_pattern.opt");
+        assert!(
+            result.is_err(),
+            "Inconsistent types in list pattern should have failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_nested_pattern_type_mismatch() {
+        let source = r#"
+        data Foo = 
+        | Add(left: Foo, right: Foo)
+        | List(bla: [Foo])
+        \ Const(val: I64)
+    
+        data Bar = 
+            | Text(value: String)
+            \ Number(value: F64)
+        
+        // This should fail due to type mismatch in nested patterns
+        fn process_nested(items: [[Foo]]): I64 = match items
+            | [] -> 0
+            | [[Text("w") .. []] .. rest] -> 1  // Error: Text is not compatible with Foo
+            \ _ -> -1
+            
+        fn main(): I64 =
+            let dat = [
+                [Const(5)],
+                [Add(Const(2), Const(3))]
+            ] in
+            process_nested(dat)
+        "#;
+
+        let result = run_type_inference(source, "nested_pattern_type_mismatch.opt");
+        assert!(
+            result.is_err(),
+            "Type mismatch in nested pattern should have failed type inference"
+        );
+    }
+
+    #[test]
+    fn test_incompatible_array_usage() {
+        let source = r#"
+        data Foo = 
+            | Add(left: Foo, right: Foo)
+            | List(bla: [Foo])
+            \ Const(val: I64)
+        
+        // This should fail because we're trying to use the array as a function with wrong parameter type
+        fn main(): Foo = 
+            let arr = [Const(1), Const(2)] in
+            arr("index")  // Error: String index for array that expects I64
+        "#;
+
+        let result = run_type_inference(source, "incompatible_array_usage.opt");
+        assert!(
+            result.is_err(),
+            "Using string index on array should have failed type inference"
         );
     }
 }

--- a/optd/src/dsl/analyzer/type_checks/solver.rs
+++ b/optd/src/dsl/analyzer/type_checks/solver.rs
@@ -2,7 +2,7 @@ use super::registry::{Constraint, Type, TypeRegistry};
 use crate::dsl::{
     analyzer::{
         errors::AnalyzerErrorKind,
-        hir::{Identifier, TypedSpan},
+        hir::{Identifier, Pattern, PatternKind, TypedSpan},
         type_checks::registry::TypeKind,
     },
     utils::span::Span,
@@ -71,6 +71,10 @@ impl TypeRegistry {
 
             Constraint::Call { inner, args, outer } => {
                 self.check_call_constraint(inner, args, outer)
+            }
+
+            Constraint::Scrutinee { scrutinee, pattern } => {
+                self.check_pattern_match_constraint(scrutinee, pattern)
             }
 
             Constraint::FieldAccess {
@@ -245,6 +249,68 @@ impl TypeRegistry {
                 ),
                 false,
             )),
+        }
+    }
+
+    fn check_pattern_match_constraint(
+        &mut self,
+        scrutinee: &TypedSpan,
+        pattern: &Pattern<TypedSpan>,
+    ) -> ConstraintResult {
+        use PatternKind::*;
+
+        let scrutinee_ty = self.resolve_type(&scrutinee.ty);
+        if matches!(*scrutinee_ty.value, TypeKind::Nothing) {
+            // TODO: May also throw an error here.
+            return Ok(false);
+        }
+
+        match &pattern.kind {
+            Bind(_, sub_pattern) => self.check_pattern_match_constraint(scrutinee, sub_pattern),
+            Struct(name, field_patterns) => {
+                let field_checks_result = field_patterns.iter().enumerate().fold(
+                    Ok(false),
+                    |acc_result, (i, field_pat)| {
+                        let field_type = self.get_product_field_type_by_index(name, i).unwrap();
+                        let field_scrutinee =
+                            TypedSpan::new(field_type, field_pat.metadata.span.clone());
+
+                        let field_result =
+                            self.check_pattern_match_constraint(&field_scrutinee, field_pat);
+                        self.combine_results(acc_result, field_result)
+                    },
+                );
+
+                let pattern_check = self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty);
+                self.combine_results(field_checks_result, pattern_check)
+            }
+            Operator(_) => panic!("Operators may not be in the HIR yet"),
+            ArrayDecomp(head, tail) => {
+                // TODO: What about OPTIONAL???????????
+                let head_check = if let TypeKind::Array(ty) = &*scrutinee_ty {
+                    // We duplicate the span out of lack of any better way to do this for now.
+                    let inner_scrutinee = TypedSpan::new(ty.clone(), scrutinee.span.clone());
+                    self.check_pattern_match_constraint(&inner_scrutinee, head)
+                } else {
+                    // TODO: Add a special error here.
+                    todo!("Add a special error here: not array!")
+                };
+                let tail_check = self.check_pattern_match_constraint(scrutinee, tail);
+                let inner_check = self.combine_results(head_check, tail_check);
+
+                let outer_check = self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty);
+
+                self.combine_results(inner_check, outer_check)
+            }
+            EmptyArray | Literal(_) => {
+                self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty)
+            }
+            Wildcard => {
+                // Here, we just try to enforce the wildcard type to be the same as the scrutinee type.
+                let lhs = self.check_subtype_constraint(scrutinee, &pattern.metadata.ty);
+                let rhs = self.check_subtype_constraint(&pattern.metadata, &scrutinee_ty);
+                self.combine_results(lhs, rhs)
+            }
         }
     }
 }

--- a/optd/src/dsl/analyzer/type_checks/solver.rs
+++ b/optd/src/dsl/analyzer/type_checks/solver.rs
@@ -268,16 +268,15 @@ impl TypeRegistry {
         match &pattern.kind {
             Bind(_, sub_pattern) => self.check_pattern_match_constraint(scrutinee, sub_pattern),
             Struct(name, field_patterns) => {
-                let field_checks_result = field_patterns.iter().enumerate().fold(
-                    Ok(false),
-                    |acc_result, (i, field_pat)| {
+                let field_checks_result = field_patterns.iter().enumerate().try_fold(
+                    false,
+                    |acc_changed, (i, field_pat)| {
                         let field_type = self.get_product_field_type_by_index(name, i).unwrap();
                         let field_scrutinee =
                             TypedSpan::new(field_type, field_pat.metadata.span.clone());
 
-                        let field_result =
-                            self.check_pattern_match_constraint(&field_scrutinee, field_pat);
-                        self.combine_results(acc_result, field_result)
+                        self.check_pattern_match_constraint(&field_scrutinee, field_pat)
+                            .map(|changed| acc_changed | changed)
                     },
                 );
 

--- a/optd/src/dsl/analyzer/type_checks/solver.rs
+++ b/optd/src/dsl/analyzer/type_checks/solver.rs
@@ -72,7 +72,7 @@ impl TypeRegistry {
             }
 
             Constraint::Scrutinee { scrutinee, pattern } => {
-                self.check_pattern_match_constraint(scrutinee, pattern, changed)
+                self.check_scrutinee_constraint(scrutinee, pattern, changed)
             }
 
             Constraint::FieldAccess {
@@ -230,7 +230,7 @@ impl TypeRegistry {
         }
     }
 
-    fn check_pattern_match_constraint(
+    fn check_scrutinee_constraint(
         &mut self,
         scrutinee: &TypedSpan,
         pattern: &Pattern<TypedSpan>,
@@ -247,7 +247,7 @@ impl TypeRegistry {
 
         match &pattern.kind {
             Bind(_, sub_pattern) => {
-                self.check_pattern_match_constraint(scrutinee, sub_pattern, changed)
+                self.check_scrutinee_constraint(scrutinee, sub_pattern, changed)
             }
 
             Struct(name, field_patterns) => {
@@ -259,7 +259,7 @@ impl TypeRegistry {
                         let field_scrutinee =
                             TypedSpan::new(field_type, field_pat.metadata.span.clone());
 
-                        self.check_pattern_match_constraint(&field_scrutinee, field_pat, changed)
+                        self.check_scrutinee_constraint(&field_scrutinee, field_pat, changed)
                     })?;
 
                 self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty, changed)
@@ -271,10 +271,10 @@ impl TypeRegistry {
                 if let Array(ty) = &*scrutinee_ty.value {
                     // First check head pattern against element type.
                     let inner_scrutinee = TypedSpan::new(ty.clone(), scrutinee.span.clone());
-                    self.check_pattern_match_constraint(&inner_scrutinee, head, changed)?;
+                    self.check_scrutinee_constraint(&inner_scrutinee, head, changed)?;
 
                     // Then check tail pattern.
-                    self.check_pattern_match_constraint(scrutinee, tail, changed)
+                    self.check_scrutinee_constraint(scrutinee, tail, changed)
                 } else {
                     Err(AnalyzerErrorKind::new_invalid_array_decomposition(
                         &scrutinee.span,

--- a/optd/src/dsl/analyzer/type_checks/solver.rs
+++ b/optd/src/dsl/analyzer/type_checks/solver.rs
@@ -9,9 +9,6 @@ use crate::dsl::{
 };
 use std::mem;
 
-/// Result type for constraint checking that tracks type changes even on error
-type ConstraintResult = Result<bool, (Box<AnalyzerErrorKind>, bool)>;
-
 impl TypeRegistry {
     /// Resolves all collected constraints and fills in the concrete types.
     ///
@@ -21,8 +18,8 @@ impl TypeRegistry {
     ///
     /// # Returns
     ///
-    /// * `Ok(())` if all constraints are successfully resolved
-    /// * `Err(error)` containing the last encountered type error when no further progress could be made
+    /// * `Ok(())` if all constraints are successfully resolved.
+    /// * `Err(error)` containing the last encountered type error when no further progress could be made.
     pub fn resolve(&mut self) -> Result<(), Box<AnalyzerErrorKind>> {
         let mut any_changed = true;
         let mut last_error = None;
@@ -35,13 +32,14 @@ impl TypeRegistry {
             let constraints = mem::take(&mut self.constraints);
 
             for constraint in &constraints {
-                match self.check_constraint(constraint) {
-                    Ok(changed) => {
-                        any_changed |= changed;
+                let mut constraint_changed = false;
+                match self.check_constraint(constraint, &mut constraint_changed) {
+                    Ok(()) => {
+                        any_changed |= constraint_changed;
                     }
-                    Err((err, changed)) => {
+                    Err(err) => {
                         // Store the error but continue processing other constraints.
-                        any_changed |= changed;
+                        any_changed |= constraint_changed;
                         last_error = Some(err);
                     }
                 }
@@ -58,30 +56,30 @@ impl TypeRegistry {
         }
     }
 
-    /// Checks if a single constraint is satisfied.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(bool)` - The constraint is satisfied, with a boolean indicating if any types were changed.
-    /// * `Err((Box<AnalyzerErrorKind>, bool))` - The constraint failed, with the error and a boolean
-    ///   indicating if any types were changed during the check.
-    fn check_constraint(&mut self, constraint: &Constraint) -> ConstraintResult {
+    /// Checks if a single constraint is satisfied
+    fn check_constraint(
+        &mut self,
+        constraint: &Constraint,
+        changed: &mut bool,
+    ) -> Result<(), Box<AnalyzerErrorKind>> {
         match constraint {
-            Constraint::Subtype { child, parent } => self.check_subtype_constraint(child, parent),
+            Constraint::Subtype { child, parent } => {
+                self.check_subtype_constraint(child, parent, changed)
+            }
 
             Constraint::Call { inner, args, outer } => {
-                self.check_call_constraint(inner, args, outer)
+                self.check_call_constraint(inner, args, outer, changed)
             }
 
             Constraint::Scrutinee { scrutinee, pattern } => {
-                self.check_pattern_match_constraint(scrutinee, pattern)
+                self.check_pattern_match_constraint(scrutinee, pattern, changed)
             }
 
             Constraint::FieldAccess {
                 inner,
                 field,
                 outer,
-            } => self.check_field_access_constraint(inner, field, outer),
+            } => self.check_field_access_constraint(inner, field, outer, changed),
         }
     }
 
@@ -89,21 +87,18 @@ impl TypeRegistry {
         &mut self,
         child: &TypedSpan,
         parent_ty: &Type,
-    ) -> ConstraintResult {
-        let mut has_changed = false;
-        let is_subtype = self.is_subtype_infer(&child.ty, parent_ty, &mut has_changed);
-
-        if is_subtype {
-            Ok(has_changed)
-        } else {
-            let err = AnalyzerErrorKind::new_invalid_subtype(
-                &child.ty,
-                parent_ty,
-                &child.span,
-                self.resolved_unknown.clone(),
-            );
-            Err((err, has_changed))
-        }
+        changed: &mut bool,
+    ) -> Result<(), Box<AnalyzerErrorKind>> {
+        self.is_subtype_infer(&child.ty, parent_ty, changed)
+            .then_some(())
+            .ok_or_else(|| {
+                AnalyzerErrorKind::new_invalid_subtype(
+                    &child.ty,
+                    parent_ty,
+                    &child.span,
+                    self.resolved_unknown.clone(),
+                )
+            })
     }
 
     fn check_call_constraint(
@@ -111,11 +106,12 @@ impl TypeRegistry {
         inner: &TypedSpan,
         args: &[TypedSpan],
         outer: &TypedSpan,
-    ) -> ConstraintResult {
+        changed: &mut bool,
+    ) -> Result<(), Box<AnalyzerErrorKind>> {
         let inner_resolved = self.resolve_type(&inner.ty);
 
         match &*inner_resolved.value {
-            TypeKind::Nothing => Ok(false),
+            TypeKind::Nothing => Ok(()),
 
             TypeKind::Closure(param, ret) => {
                 let (param_len, param_types) = match &**param {
@@ -125,56 +121,50 @@ impl TypeRegistry {
                 };
 
                 if param_len != args.len() {
-                    return Err((
-                        AnalyzerErrorKind::new_argument_number_mismatch(
-                            &inner.span,
-                            param_len,
-                            args.len(),
-                        ),
-                        false,
+                    return Err(AnalyzerErrorKind::new_argument_number_mismatch(
+                        &inner.span,
+                        param_len,
+                        args.len(),
                     ));
                 }
 
-                let param_result = args.iter().zip(param_types.iter()).try_fold(
-                    false,
-                    |acc_changes, (arg, param_type)| match self
-                        .check_subtype_constraint(arg, param_type)
-                    {
-                        Ok(changed) => Ok(acc_changes | changed),
-                        Err((err, changed)) => Err((err, acc_changes | changed)),
-                    },
-                );
-                let ret_result = self.check_subtype_constraint(
+                args.iter()
+                    .zip(param_types.iter())
+                    .try_for_each(|(arg, param_type)| {
+                        self.check_subtype_constraint(arg, param_type, changed)
+                    })?;
+
+                self.check_subtype_constraint(
                     &TypedSpan::new(ret.clone(), inner.span.clone()),
                     &outer.ty,
-                );
-
-                self.combine_results(param_result, ret_result)
+                    changed,
+                )
             }
 
-            // Maps are callable with key type for indexing.
             TypeKind::Map(key_type, val_type) => {
-                self.check_indexable(&inner.span, args, key_type, val_type, &outer.ty)
+                self.check_indexable(&inner.span, args, key_type, val_type, &outer.ty, changed)
             }
 
-            // Arrays are callable with integer indices.
             TypeKind::Array(elem_type) => {
                 let index_type = TypeKind::I64.into();
-                self.check_indexable(&inner.span, args, &index_type, elem_type, &outer.ty)
+                self.check_indexable(
+                    &inner.span,
+                    args,
+                    &index_type,
+                    elem_type,
+                    &outer.ty,
+                    changed,
+                )
             }
 
-            _ => Err((
-                AnalyzerErrorKind::new_invalid_call_receiver(
-                    &inner_resolved,
-                    &inner.span,
-                    self.resolved_unknown.clone(),
-                ),
-                false,
+            _ => Err(AnalyzerErrorKind::new_invalid_call_receiver(
+                &inner_resolved,
+                &inner.span,
+                self.resolved_unknown.clone(),
             )),
         }
     }
 
-    // Helper for array/map indexing operations where lookups might fail.
     fn check_indexable(
         &mut self,
         span: &Span,
@@ -182,20 +172,26 @@ impl TypeRegistry {
         key_type: &Type,
         elem_type: &Type,
         outer_ty: &Type,
-    ) -> ConstraintResult {
+        changed: &mut bool,
+    ) -> Result<(), Box<AnalyzerErrorKind>> {
         if args.len() != 1 {
-            return Err((
-                AnalyzerErrorKind::new_argument_number_mismatch(span, 1, args.len()),
-                false,
+            return Err(AnalyzerErrorKind::new_argument_number_mismatch(
+                span,
+                1,
+                args.len(),
             ));
         }
 
-        let index_result = self.check_subtype_constraint(&args[0], key_type);
-        let optional_elem_type = TypeKind::Optional(elem_type.clone()).into();
-        let elem_result = self
-            .check_subtype_constraint(&TypedSpan::new(optional_elem_type, span.clone()), outer_ty);
+        // Check index type.
+        self.check_subtype_constraint(&args[0], key_type, changed)?;
 
-        self.combine_results(index_result, elem_result)
+        // Check element type (wrapped in Optional).
+        let optional_elem_type = TypeKind::Optional(elem_type.clone()).into();
+        self.check_subtype_constraint(
+            &TypedSpan::new(optional_elem_type, span.clone()),
+            outer_ty,
+            changed,
+        )
     }
 
     fn check_field_access_constraint(
@@ -203,41 +199,33 @@ impl TypeRegistry {
         inner: &TypedSpan,
         field: &Identifier,
         outer: &Type,
-    ) -> ConstraintResult {
+        changed: &mut bool,
+    ) -> Result<(), Box<AnalyzerErrorKind>> {
         let inner_resolved = self.resolve_type(&inner.ty);
 
         match &*inner_resolved.value {
-            TypeKind::Nothing => Ok(false),
+            // Wait for the field access to be resolved.
+            TypeKind::Nothing => Ok(()),
 
-            TypeKind::Adt(name) => {
-                match self.get_product_field_type(name, field) {
-                    Some(field_ty) => {
-                        // Check that the field type is a subtype of the outer type.
-                        self.check_subtype_constraint(
-                            &TypedSpan::new(field_ty, inner.span.clone()),
-                            outer,
-                        )
-                    }
-                    None => Err((
-                        AnalyzerErrorKind::new_invalid_field_access(
-                            &inner_resolved,
-                            &inner.span,
-                            field,
-                            self.resolved_unknown.clone(),
-                        ),
-                        false,
-                    )),
-                }
-            }
-
-            _ => Err((
-                AnalyzerErrorKind::new_invalid_field_access(
+            TypeKind::Adt(name) => match self.get_product_field_type(name, field) {
+                Some(field_ty) => self.check_subtype_constraint(
+                    &TypedSpan::new(field_ty, inner.span.clone()),
+                    outer,
+                    changed,
+                ),
+                None => Err(AnalyzerErrorKind::new_invalid_field_access(
                     &inner_resolved,
                     &inner.span,
                     field,
                     self.resolved_unknown.clone(),
-                ),
-                false,
+                )),
+            },
+
+            _ => Err(AnalyzerErrorKind::new_invalid_field_access(
+                &inner_resolved,
+                &inner.span,
+                field,
+                self.resolved_unknown.clone(),
             )),
         }
     }
@@ -246,90 +234,68 @@ impl TypeRegistry {
         &mut self,
         scrutinee: &TypedSpan,
         pattern: &Pattern<TypedSpan>,
-    ) -> ConstraintResult {
+        changed: &mut bool,
+    ) -> Result<(), Box<AnalyzerErrorKind>> {
         use PatternKind::*;
         use TypeKind::*;
 
         let scrutinee_ty = self.resolve_type(&scrutinee.ty);
         if matches!(*scrutinee_ty.value, TypeKind::Nothing) {
-            return Ok(false);
+            // Wait for the scrutinee to be resolved.
+            return Ok(());
         }
 
         match &pattern.kind {
-            Bind(_, sub_pattern) => self.check_pattern_match_constraint(scrutinee, sub_pattern),
+            Bind(_, sub_pattern) => {
+                self.check_pattern_match_constraint(scrutinee, sub_pattern, changed)
+            }
 
             Struct(name, field_patterns) => {
-                // Process all field patterns using fold to accumulate all changes and errors.
-                // Using #[allow(clippy::manual_try_fold)] to silence the warning since we specifically
-                // don't want try_fold's early-return behavior.
-                #[allow(clippy::manual_try_fold)]
-                let field_checks_result = field_patterns.iter().enumerate().fold(
-                    Ok(false),
-                    |acc_result, (i, field_pat)| {
+                field_patterns
+                    .iter()
+                    .enumerate()
+                    .try_for_each(|(i, field_pat)| {
                         let field_type = self.get_product_field_type_by_index(name, i).unwrap();
                         let field_scrutinee =
                             TypedSpan::new(field_type, field_pat.metadata.span.clone());
 
-                        let field_result =
-                            self.check_pattern_match_constraint(&field_scrutinee, field_pat);
+                        self.check_pattern_match_constraint(&field_scrutinee, field_pat, changed)
+                    })?;
 
-                        self.combine_results(acc_result, field_result)
-                    },
-                );
-
-                let pattern_check = self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty);
-                self.combine_results(field_checks_result, pattern_check)
+                self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty, changed)
             }
 
             Operator(_) => panic!("Operators may not be in the HIR yet"),
 
             ArrayDecomp(head, tail) => {
-                let head_check = if let Array(ty) = &*scrutinee_ty.value {
+                if let Array(ty) = &*scrutinee_ty.value {
+                    // First check head pattern against element type.
                     let inner_scrutinee = TypedSpan::new(ty.clone(), scrutinee.span.clone());
-                    self.check_pattern_match_constraint(&inner_scrutinee, head)
+                    self.check_pattern_match_constraint(&inner_scrutinee, head, changed)?;
+
+                    // Then check tail pattern.
+                    self.check_pattern_match_constraint(scrutinee, tail, changed)
                 } else {
-                    return Err((
-                        AnalyzerErrorKind::new_invalid_array_decomposition(
-                            &scrutinee.span,
-                            &pattern.metadata.span,
-                            &scrutinee_ty,
-                            self.resolved_unknown.clone(),
-                        ),
-                        false,
-                    ));
-                };
-
-                let tail_check = self.check_pattern_match_constraint(scrutinee, tail);
-                let inner_check = self.combine_results(head_check, tail_check);
-                let pattern_check = self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty);
-
-                self.combine_results(inner_check, pattern_check)
+                    Err(AnalyzerErrorKind::new_invalid_array_decomposition(
+                        &scrutinee.span,
+                        &pattern.metadata.span,
+                        &scrutinee_ty,
+                        self.resolved_unknown.clone(),
+                    ))
+                }
             }
 
             EmptyArray | Literal(_) => {
-                self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty)
+                self.check_subtype_constraint(&pattern.metadata, &scrutinee.ty, changed)
             }
 
             Wildcard => {
-                // Here, we just try to enforce the wildcard type to be the same as the scrutinee type.
-                let lhs = self.check_subtype_constraint(scrutinee, &pattern.metadata.ty);
-                let rhs = self.check_subtype_constraint(&pattern.metadata, &scrutinee_ty);
-                self.combine_results(lhs, rhs)
-            }
-        }
-    }
+                // First check scrutinee against wildcard type.
+                self.check_subtype_constraint(scrutinee, &pattern.metadata.ty, changed)?;
 
-    // Combines results while preserving type changes and prioritizing the first error
-    fn combine_results(
-        &self,
-        result1: ConstraintResult,
-        result2: ConstraintResult,
-    ) -> ConstraintResult {
-        match (result1, result2) {
-            (Ok(changed1), Ok(changed2)) => Ok(changed1 | changed2),
-            (Ok(changed1), Err((err2, changed2))) => Err((err2, changed1 | changed2)),
-            (Err((err1, changed1)), Ok(changed2)) => Err((err1, changed1 | changed2)),
-            (Err((err1, changed1)), Err((_, changed2))) => Err((err1, changed1 | changed2)),
+                // Then check wildcard pattern against scrutinee type
+                self.check_subtype_constraint(&pattern.metadata, &scrutinee_ty, changed)
+            }
         }
     }
 }

--- a/optd/src/dsl/examples/higher_order.opt
+++ b/optd/src/dsl/examples/higher_order.opt
@@ -62,7 +62,7 @@ fn constant_folder(): Logical -> Logical =
 fn arrays(a: [Binary]) = none
 
 [implementation]
-fn (phys: Physical*) implementation(prop: PhysicalProperties) = 5
+fn (log: Logical*) implementation(prop: PhysicalProperties?) = none
 
 [transformation]
 fn main(log: Logical): Logical = 

--- a/optd/src/dsl/examples/simple.opt
+++ b/optd/src/dsl/examples/simple.opt
@@ -16,12 +16,12 @@ fn main(log: Logical): Logical? = match log
         let closure = x -> right in
         closure(5)
     }
-    | fooo -> arr_as_function(Const(54), 0, [log])
+    | fooo -> arr_as_function(fooo, 0, [log])
     | List(bla) -> match bla
         | vla -> vla(0)
         \ [] -> none
     | Add(left, right) -> left
     \ _ -> fail("brru")
 
-fn (log: [Logical]) vla: List = match log 
-    \ [Const(5) .. [v .. []]] -> v
+fn (log: [Logical]) vla: [Logical] = match log 
+    \ [Const(5) .. [List([Const(5) .. _]) .. v]] -> v


### PR DESCRIPTION
### What

Adds list pattern matching in the DSL. This partially addresses #81 .

Programs as follows now properly type check.

```
data Logical =
    | Add(left: Logical, right: Logical)
    | List(bla: [Logical])
    \ Const(val: I64)
    
data Physical
data LogicalProperties
data PhysicalProperties

fn (log: Logical) fold = x -> x

fn arr_as_function(other: Logical, idx: I64, closure: I64 -> Logical?) = closure(idx)

fn main(log: Logical): Logical? = match log 
    | Add(Add(_, _), right: Const(val)) -> {
        let closure = x -> right in
        closure(5)
    }
    | fooo -> arr_as_function(fooo, 0, [log])
    | List(bla) -> match bla
        | vla -> vla(0)
        \ [] -> none
    | Add(left, right) -> left
    \ _ -> fail("brru")

fn (log: [Logical]) vla(): [Logical] = match log 
    \ [Const(5) .. [List([Const(5) .. _]) .. v]] -> v
```

### How

Added the `Constraint::Scrutinee` constraint, and the `InvalidArrayDecomposition` error. Most of the code that used to be in `generate.rs` has been moved to `solver.rs` as the type contained in the array needs to be properly resolved before we can check if the nested pattern fields are valid.

### Next steps

Continue addressing #81 , specifically generic types and concatenation. 