### PR TITLE
(feat) Execute DSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
  "clap",
  "colored",
  "optd",
+ "tokio",
 ]
 
 [[package]]

--- a/optd-cli/Cargo.toml
+++ b/optd-cli/Cargo.toml
@@ -9,3 +9,4 @@ optd = { path = "../optd" }
 
 clap = { version = "4.5.37", features = ["derive"] }
 colored = "3.0.0"
+tokio = "1.44.2"

--- a/optd-cli/examples/logical_rules.opt
+++ b/optd-cli/examples/logical_rules.opt
@@ -206,7 +206,7 @@ fn run_add_by_zero() =
     add_by_zero(addition)
 
 [run]
-fn (logical: Logical) run_double_neg() =
+fn run_double_neg() =
   let
     const13 = Const(13),
     neg1 = Neg(const13),

--- a/optd-cli/examples/logical_rules.opt
+++ b/optd-cli/examples/logical_rules.opt
@@ -206,7 +206,7 @@ fn run_add_by_zero() =
     add_by_zero(addition)
 
 [run]
-fn run_double_neg() =
+fn (logical: Logical) run_double_neg() =
   let
     const13 = Const(13),
     neg1 = Neg(const13),

--- a/optd-cli/examples/logical_rules.opt
+++ b/optd-cli/examples/logical_rules.opt
@@ -1,0 +1,281 @@
+data Physical
+data PhysicalProperties
+data Statistics
+data LogicalProperties
+
+data Logical =
+  | Add(left: Logical, right: Logical)
+  | Sub(left: Logical, right: Logical)
+  | Mult(left: Logical, right: Logical)
+  | Div(left: Logical, right: Logical)
+  | Pow(base: Logical, exponent: Logical)
+  | Neg(expr: Logical)
+  | Max(left: Logical, right: Logical)
+  | Min(left: Logical, right: Logical)
+  \ Const(val: I64)
+
+fn recursive_power(base: I64, exp: I64): I64 =
+  if exp == 0 then 
+    1
+  else if exp == 1 then 
+    base
+  else 
+    base * recursive_power(base, exp - 1)
+
+fn (op: Logical) evaluate(): I64 = match op
+  | Add(left, right) -> left.evaluate() + right.evaluate()
+  | Sub(left, right) -> left.evaluate() - right.evaluate()
+  | Mult(left, right) -> left.evaluate() * right.evaluate()
+  | Div(left, right) -> 
+      let r = right.evaluate() in
+      if r == 0 then 
+        fail("cannot div by zero")
+      else 
+        left.evaluate() / r
+  | Pow(base, exp) -> 
+      let 
+        b = base.evaluate(),
+        e = exp.evaluate()
+      in
+        if e < 0 then fail("negative exponent") else recursive_power(b, e)
+  | Neg(expr) -> -expr.evaluate()
+  | Max(left, right) -> 
+      let 
+        l = left.evaluate(),
+        r = right.evaluate()
+      in
+        if l > r then l else r
+  | Min(left, right) -> 
+      let 
+        l = left.evaluate(),
+        r = right.evaluate()
+      in
+        if l < r then l else r
+  \ Const(val) -> val
+
+fn (op: Logical) mult_commute(): Logical? = match op
+  | Mult(left, right) -> Mult(right, left)
+  \ _ -> none
+
+fn (op: Logical) add_commute(): Logical? = match op
+  | Add(left, right) -> Add(right, left)
+  \ _ -> none
+
+fn (op: Logical) const_fold_add(): Logical? = match op
+  | Add(Const(a), Const(b)) -> Const(a + b)
+  \ _ -> none
+
+fn (op: Logical) const_fold_mult(): Logical? = match op
+  | Mult(Const(a), Const(b)) -> Const(a * b)
+  \ _ -> none
+
+fn (op: Logical) const_fold_sub(): Logical? = match op
+  | Sub(Const(a), Const(b)) -> Const(a - b)
+  \ _ -> none
+
+fn (op: Logical) const_fold_div(): Logical? = match op
+  | Div(Const(a), Const(b)) -> 
+      if b == 0 then none else Const(a / b)
+  \ _ -> none
+
+fn (op: Logical) mult_by_zero(): Logical? = match op
+  | Mult(_, Const(0)) -> Const(0)
+  | Mult(Const(0), _) -> Const(0)
+  \ _ -> none
+
+fn (op: Logical) mult_by_one(): Logical? = match op
+  | Mult(expr, Const(1)) -> expr
+  | Mult(Const(1), expr) -> expr
+  \ _ -> none
+
+fn (op: Logical) add_by_zero(): Logical? = match op
+  | Add(expr, Const(0)) -> expr
+  | Add(Const(0), expr) -> expr
+  \ _ -> none
+
+fn (op: Logical) double_neg(): Logical? = match op
+  | Neg(Neg(expr)) -> expr
+  \ _ -> none
+
+fn (op: Logical) pow_zero(): Logical? = match op
+  | Pow(_, Const(0)) -> Const(1)
+  \ _ -> none
+
+fn (op: Logical) pow_one(): Logical? = match op
+  | Pow(base, Const(1)) -> base
+  \ _ -> none
+
+fn (op: Logical) distributive(): Logical? = match op
+  | Mult(factor, Add(left, right)) -> 
+      Add(Mult(factor, left), Mult(factor, right))
+  | Mult(Add(left, right), factor) -> 
+      Add(Mult(left, factor), Mult(right, factor))
+  \ _ -> none
+
+fn (op: Logical) sub_to_add(): Logical? = match op
+  | Sub(left, right) -> Add(left, Neg(right))
+  \ _ -> none
+
+fn (op: Logical) same_minmax(): Logical? = match op
+  | Min(expr1, expr2) -> if expr1 == expr2 then expr1 else none
+  | Max(expr1, expr2) -> if expr1 == expr2 then expr1 else none
+  \ _ -> none
+
+fn (op: Logical) const_fold_minmax(): Logical? = match op
+  | Min(Const(a), Const(b)) -> Const(if a < b then a else b)
+  | Max(Const(a), Const(b)) -> Const(if a > b then a else b)
+  \ _ -> none
+
+fn (op: Logical) nested_minmax(): Logical? = match op
+  | Min(Min(a, b), c) -> Min(a, Min(b, c))
+  | Max(Max(a, b), c) -> Max(a, Max(b, c))
+  \ _ -> none
+
+[run]
+fn build_calculator_expr() =
+  let
+    const2 = Const(2),
+    const3 = Const(3),
+    const4 = Const(4),
+    addition = Add(const2, const3),
+    multiplication = Mult(addition, const4)
+  in
+    multiplication.evaluate()
+
+[run]
+fn run_mult_commute() =
+  let
+    const5 = Const(5),
+    const10 = Const(10),
+    mult = Mult(const5, const10)
+  in
+    mult_commute(mult)
+
+[run]
+fn run_add_commute() =
+  let
+    const7 = Const(7),
+    const12 = Const(12),
+    addition = Add(const7, const12)
+  in
+    add_commute(addition)
+
+[run]
+fn run_const_fold_add() =
+  let
+    const5 = Const(5),
+    const8 = Const(8),
+    addition = Add(const5, const8)
+  in
+    const_fold_add(addition)
+
+[run]
+fn run_const_fold_mult() =
+  let
+    const6 = Const(6),
+    const9 = Const(9),
+    multiplication = Mult(const6, const9)
+  in
+    const_fold_mult(multiplication)
+
+[run]
+fn run_mult_by_zero() =
+  let
+    const0 = Const(0),
+    const42 = Const(42),
+    multiplication = Mult(const42, const0)
+  in
+    mult_by_zero(multiplication)
+
+[run]
+fn run_mult_by_one() =
+  let
+    const1 = Const(1),
+    const25 = Const(25),
+    multiplication = Mult(const1, const25)
+  in
+    mult_by_one(multiplication)
+
+[run]
+fn run_add_by_zero() =
+  let
+    const0 = Const(0),
+    const17 = Const(17),
+    addition = Add(const17, const0)
+  in
+    add_by_zero(addition)
+
+[run]
+fn run_double_neg() =
+  let
+    const13 = Const(13),
+    neg1 = Neg(const13),
+    neg2 = Neg(neg1)
+  in
+    double_neg(neg2)
+
+[run]
+fn run_distributive() =
+  let
+    const2 = Const(2),
+    const3 = Const(3),
+    const4 = Const(4),
+    addition = Add(const3, const4),
+    multiplication = Mult(const2, addition)
+  in
+    distributive(multiplication)
+
+[run]
+fn run_sub_to_add() =
+  let
+    const8 = Const(8),
+    const3 = Const(3),
+    subtraction = Sub(const8, const3)
+  in
+    sub_to_add(subtraction)
+
+// [run]
+// fn run_same_minmax() =
+//   let
+//     const5 = Const(5),
+//     min_op = Min(const5, const5)
+//   in
+//     same_minmax(min_op)
+
+[run]
+fn run_const_fold_minmax() =
+  let
+    const8 = Const(8),
+    const15 = Const(15),
+    min_op = Min(const8, const15)
+  in
+    const_fold_minmax(min_op)
+
+[run]
+fn run_nested_minmax() =
+  let
+    const3 = Const(3),
+    const6 = Const(6),
+    const9 = Const(9),
+    inner_min = Min(const3, const6),
+    outer_min = Min(inner_min, const9)
+  in
+    nested_minmax(outer_min)
+
+[run]
+fn run_pow_zero() =
+  let
+    const7 = Const(7),
+    const0 = Const(0),
+    pow_zero_expr = Pow(const7, const0)
+  in
+    pow_zero(pow_zero_expr)
+
+[run]
+fn run_division_by_zero() =
+  let
+    const5 = Const(5),
+    const0 = Const(0),
+    division = Div(const5, const0)
+  in
+    division.evaluate()

--- a/optd-cli/src/main.rs
+++ b/optd-cli/src/main.rs
@@ -17,6 +17,9 @@
 //! # Get help:
 //! optd-cli --help
 //! optd-cli compile --help
+//!
+//! # Run functions marked with [run] annotation:
+//! optd-cli run-functions path/to/file.opt
 //! ```
 //!
 //! When developing, you can run through cargo:
@@ -26,15 +29,21 @@
 //! cargo run --bin optd-cli -- compile path/to/example.opt --verbose
 //! cargo run --bin optd-cli -- compile path/to/example.opt --verbose --show-ast --show-hir
 //! cargo run --bin optd-cli -- compile path/to/example.opt --mock-udfs hello get_schema world
+//! cargo run --bin optd-cli -- run-functions path/to/example.opt
 //! ```
 
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use optd::catalog::Catalog;
-use optd::dsl::analyzer::hir::{CoreData, Udf, Value};
+use optd::catalog::iceberg::memory_catalog;
+use optd::dsl::analyzer::hir::{CoreData, HIR, Udf, Value};
 use optd::dsl::compile::{Config, compile_hir};
+use optd::dsl::engine::{Continuation, Engine, EngineResponse};
 use optd::dsl::utils::errors::{CompileError, Diagnose};
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::task::JoinSet;
 
 #[derive(Parser)]
 #[command(
@@ -52,6 +61,8 @@ struct Cli {
 enum Commands {
     /// Compile a DSL file (parse and analyze).
     Compile(Config),
+    /// Run functions annotated with [run].
+    RunFunctions(Config),
 }
 
 /// A unimplemented user-defined function.
@@ -69,17 +80,133 @@ fn main() -> Result<(), Vec<CompileError>> {
     };
     udfs.insert("unimplemented_udf".to_string(), udf.clone());
 
-    let Commands::Compile(config) = cli.command;
+    match cli.command {
+        Commands::Compile(config) => {
+            for mock_udf in config.mock_udfs() {
+                udfs.insert(mock_udf.to_string(), udf.clone());
+            }
 
-    for mock_udf in config.mock_udfs() {
-        udfs.insert(mock_udf.to_string(), udf.clone());
+            let _ = compile_hir(config, udfs).unwrap_or_else(|errors| handle_errors(&errors));
+            Ok(())
+        }
+        Commands::RunFunctions(config) => {
+            // TODO(Connor): Add support for running functions with real UDFs.
+            for mock_udf in config.mock_udfs() {
+                udfs.insert(mock_udf.to_string(), udf.clone());
+            }
+
+            let hir = compile_hir(config, udfs).unwrap_or_else(|errors| handle_errors(&errors));
+
+            run_all_functions(&hir)
+        }
+    }
+}
+
+/// Result of running a function.
+struct FunctionResult {
+    name: String,
+    result: EngineResponse<Value>,
+}
+
+/// Run all functions found in the HIR, marked with [run].
+fn run_all_functions(hir: &HIR) -> Result<(), Vec<CompileError>> {
+    println!("\n{} {}\n", "•".green(), "Running functions...".green());
+
+    let functions = find_functions(hir);
+
+    if functions.is_empty() {
+        println!("No functions found annotated with [run]");
+        return Ok(());
     }
 
-    let _hir = compile_hir(config, udfs).unwrap_or_else(|errors| handle_errors(&errors));
+    println!("Found {} functions to run", functions.len());
+
+    // Create a multi-threaded runtime for parallel execution.
+    let runtime = Runtime::new().unwrap();
+    let function_results = runtime.block_on(run_functions_in_parallel(hir, functions));
+
+    // Process and display function results.
+    let success_count = process_function_results(function_results);
+
+    println!(
+        "\n{} {}",
+        "Execution Results:".yellow(),
+        format!("{} functions executed", success_count).yellow()
+    );
 
     Ok(())
 }
 
+async fn run_functions_in_parallel(hir: &HIR, functions: Vec<String>) -> Vec<FunctionResult> {
+    let catalog = Arc::new(memory_catalog());
+    let mut set = JoinSet::new();
+
+    for function_name in functions {
+        let engine = Engine::new(hir.context.clone(), catalog.clone());
+        let name = function_name.clone();
+
+        set.spawn(async move {
+            // Create a continuation that returns itself.
+            let result_handler: Continuation<Value, Value> =
+                Arc::new(|value| Box::pin(async move { value }));
+
+            // Launch the function with an empty vector of arguments.
+            let result = engine.launch_rule(&name, vec![], result_handler).await;
+            FunctionResult { name, result }
+        });
+    }
+
+    // Collect all function results.
+    let mut results = Vec::new();
+    while let Some(result) = set.join_next().await {
+        if let Ok(function_result) = result {
+            results.push(function_result);
+        }
+    }
+
+    results
+}
+
+/// Process function results and display them.
+fn process_function_results(function_results: Vec<FunctionResult>) -> usize {
+    let mut success_count = 0;
+
+    for function_result in function_results {
+        println!("\n{} {}", "Function:".blue(), function_result.name);
+
+        match function_result.result {
+            EngineResponse::Return(value, _) => {
+                // Check if the result is a failure.
+                if matches!(value.data, CoreData::Fail(_)) {
+                    println!("  {}: Function failed: {}", "Error".red(), value);
+                } else {
+                    println!("  {}: {}", "Result".green(), value);
+                    success_count += 1;
+                }
+            }
+            _ => unreachable!(), // For now, unless we add a special UDF that builds a group / goal.
+        }
+    }
+
+    success_count
+}
+
+/// Find functions with the [run] annotation.
+fn find_functions(hir: &HIR) -> Vec<String> {
+    let mut functions = Vec::new();
+
+    for (name, _) in hir.context.get_all_bindings() {
+        if let Some(annotations) = hir.annotations.get(name) {
+            if annotations.iter().any(|a| a == "run") {
+                functions.push(name.clone());
+            }
+        }
+    }
+
+    functions
+}
+
+/// Display error details and exit the program.
 fn handle_errors(errors: &[CompileError]) -> ! {
     eprintln!(
         "\n{} {}\n",

--- a/optd/src/dsl/analyzer/hir/display.rs
+++ b/optd/src/dsl/analyzer/hir/display.rs
@@ -1,0 +1,221 @@
+//! Display implementations for HIR types.
+//!
+//! This module provides Display trait implementations for various HIR types,
+//! enabling human-readable formatting of expressions, values, and patterns.
+
+use super::map::Map;
+use super::{
+    BinOp, CoreData, FunKind, Goal, GroupId, Literal, LogicalOp, Materializable, NoMetadata,
+    PhysicalOp, UnaryOp, Value,
+};
+use std::fmt;
+
+impl fmt::Display for Value<NoMetadata> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.data {
+            CoreData::Literal(lit) => match lit {
+                Literal::Int64(i) => write!(f, "{}", i),
+                Literal::Float64(fl) => write!(f, "{}", fl),
+                Literal::String(s) => write!(f, "\"{}\"", s),
+                Literal::Bool(b) => write!(f, "{}", b),
+                Literal::Unit => write!(f, "()"),
+            },
+            CoreData::Array(items) => {
+                write!(f, "[")?;
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                write!(f, "]")
+            }
+            CoreData::Tuple(items) => {
+                write!(f, "(")?;
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                if items.len() == 1 {
+                    write!(f, ",")?; // Add trailing comma for 1-tuples
+                }
+                write!(f, ")")
+            }
+            CoreData::Map(map) => format_map(f, map),
+            CoreData::Struct(name, fields) => {
+                write!(f, "{}(", name)?;
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", field)?;
+                }
+                write!(f, ")")
+            }
+            CoreData::Function(fun_kind) => match fun_kind {
+                FunKind::Closure(params, _) => {
+                    write!(f, "λ(")?;
+                    for (i, param) in params.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", param)?;
+                    }
+                    write!(f, ") → ‹code›")
+                }
+                FunKind::Udf(_) => write!(f, "udf@native"),
+            },
+            CoreData::Fail(value) => write!(f, "fail({})", value),
+            CoreData::Logical(materializable) => match materializable {
+                Materializable::Materialized(logical_op) => format_logical_op(f, logical_op),
+                Materializable::UnMaterialized(group_id) => {
+                    write!(f, "group({})", group_id.0)
+                }
+            },
+            CoreData::Physical(materializable) => match materializable {
+                Materializable::Materialized(physical_op) => format_physical_op(f, physical_op),
+                Materializable::UnMaterialized(goal) => format_goal(f, goal),
+            },
+            CoreData::None => write!(f, "none"),
+        }
+    }
+}
+
+// Helper function to format Map contents
+fn format_map(f: &mut fmt::Formatter<'_>, map: &Map) -> fmt::Result {
+    write!(f, "{{")?;
+    let mut first = true;
+
+    // Sort keys for deterministic output
+    let mut entries: Vec<_> = map.inner.iter().collect();
+    entries.sort_by(|a, b| format!("{:?}", a.0).cmp(&format!("{:?}", b.0)));
+
+    for (key, value) in entries {
+        if !first {
+            write!(f, ", ")?;
+        }
+        first = false;
+
+        // Format the key and value
+        write!(f, "{:?} → {}", key, value)?;
+    }
+    write!(f, "}}")
+}
+
+// Helper function to format logical operators
+fn format_logical_op(f: &mut fmt::Formatter<'_>, op: &LogicalOp<Value<NoMetadata>>) -> fmt::Result {
+    write!(f, "{}(", op.operator.tag)?;
+
+    // Format data
+    for (i, data) in op.operator.data.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "{}", data)?;
+    }
+
+    // Format children if any
+    if !op.operator.children.is_empty() {
+        if !op.operator.data.is_empty() {
+            write!(f, "; ")?;
+        }
+        for (i, child) in op.operator.children.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", child)?;
+        }
+    }
+
+    // Add group_id if present
+    if let Some(group_id) = op.group_id {
+        write!(f, ")[{}]", group_id.0)
+    } else {
+        write!(f, ")")
+    }
+}
+
+// Helper function to format physical operators
+fn format_physical_op(
+    f: &mut fmt::Formatter<'_>,
+    op: &PhysicalOp<Value<NoMetadata>, NoMetadata>,
+) -> fmt::Result {
+    write!(f, "PhysOp:{}(", op.operator.tag)?;
+
+    // Format data
+    for (i, data) in op.operator.data.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "{}", data)?;
+    }
+
+    // Format children if any
+    if !op.operator.children.is_empty() {
+        if !op.operator.data.is_empty() {
+            write!(f, "; ")?;
+        }
+        for (i, child) in op.operator.children.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", child)?;
+        }
+    }
+
+    write!(f, ")")?;
+
+    // Add goal if present
+    if let Some(goal) = &op.goal {
+        write!(f, "[goal: {}]", goal.group_id.0)?;
+    }
+
+    // Add cost if present
+    if let Some(cost) = &op.cost {
+        write!(f, "[cost: {}]", cost)?;
+    }
+
+    Ok(())
+}
+
+// Helper function to format goals
+fn format_goal(f: &mut fmt::Formatter<'_>, goal: &Goal) -> fmt::Result {
+    write!(f, "Goal[{}]{{{}}}", goal.group_id.0, goal.properties)
+}
+
+// For completeness, let's add Display implementations for binary and unary operators
+
+impl fmt::Display for BinOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BinOp::Add => write!(f, "+"),
+            BinOp::Sub => write!(f, "-"),
+            BinOp::Mul => write!(f, "*"),
+            BinOp::Div => write!(f, "/"),
+            BinOp::Lt => write!(f, "<"),
+            BinOp::Eq => write!(f, "=="),
+            BinOp::And => write!(f, "&&"),
+            BinOp::Or => write!(f, "||"),
+            BinOp::Range => write!(f, ".."),
+            BinOp::Concat => write!(f, "++"),
+        }
+    }
+}
+
+impl fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnaryOp::Neg => write!(f, "-"),
+            UnaryOp::Not => write!(f, "!"),
+        }
+    }
+}
+
+// Add Display implementation for GroupId for convenience
+impl fmt::Display for GroupId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "G{}", self.0)
+    }
+}

--- a/optd/src/dsl/analyzer/hir/mod.rs
+++ b/optd/src/dsl/analyzer/hir/mod.rs
@@ -24,6 +24,7 @@ use std::fmt::Debug;
 use std::{collections::HashMap, sync::Arc};
 
 pub(crate) mod context;
+mod display;
 pub(crate) mod map;
 
 /// Unique identifier for variables, functions, types, etc.


### PR DESCRIPTION
## Overview

DSL functions can now be executed through the CLI with the `[run]` annotation.

Try it out!

`cargo run --bin optd-cli -- run-functions [path]/logical_rules.opt`

## Known Issues

- Stack overflows *very* quickly due to the lack of TCO in the engine. Needs to be optimized.
- Existing type inference issues.
