### PR TITLE
Migrate memo types and interfaces

### DIFF
--- a/optd/src/memo/error.rs
+++ b/optd/src/memo/error.rs
@@ -1,0 +1,25 @@
+use crate::cir::*;
+
+/// A type alias for results returned by the different memo table trait methods.
+///
+/// See the private `traits.rs` module for more information (note that the traits are re-exported).
+pub type MemoResult<T> = Result<T, MemoError>;
+
+/// The possible kinds of errors that memo table and task graph state operations can run into.
+#[derive(Debug, Clone, Copy)]
+pub enum MemoError {
+    /// A [`GroupId`] does not exist in the memo.
+    GroupNotFound(GroupId),
+
+    /// A [`GoalId`] does not exist in the memo.
+    GoalNotFound(GoalId),
+
+    /// A [`LogicalExpressionId`] does not exist in the memo.
+    LogicalExprNotFound(LogicalExpressionId),
+
+    /// A [`PhysicalExpressionId`] does not exist in the memo.
+    PhysicalExprNotFound(PhysicalExpressionId),
+
+    /// A group does not contain any logical expressions.
+    NoLogicalExprInGroup(GroupId),
+}

--- a/optd/src/memo/errors.rs
+++ b/optd/src/memo/errors.rs
@@ -1,3 +1,0 @@
-pub(super) enum MemoError {
-    Placeholder,
-}

--- a/optd/src/memo/memory.rs
+++ b/optd/src/memo/memory.rs
@@ -1,0 +1,1135 @@
+use super::*;
+use crate::cir::*;
+use async_recursion::async_recursion;
+use std::collections::{HashMap, HashSet, VecDeque, hash_map::Entry};
+
+/// An in-memory implementation of the memo table.
+#[derive(Default)]
+pub struct MemoryMemo {
+    /// Group id to state.
+    groups: HashMap<GroupId, GroupState>,
+
+    /// Logical expression id to node.
+    logical_exprs: HashMap<LogicalExpressionId, LogicalExpression>,
+    /// Logical expression node to id.
+    logical_expr_node_to_id_index: HashMap<LogicalExpression, LogicalExpressionId>,
+    /// A mapping from logical expression id to group id.
+    logical_expr_group_index: HashMap<LogicalExpressionId, GroupId>,
+
+    /// Dependent logical expression ids for each group id.
+    /// This is used to quickly find all the logical expressions that have a child equal to the group id, which is the key.
+    /// Dependent here does not mean the dependency stuff that we have in the memo table
+    group_dependent_logical_exprs: HashMap<GroupId, HashSet<LogicalExpressionId>>,
+
+    /// Physical expression id to node.
+    physical_exprs: HashMap<PhysicalExpressionId, (PhysicalExpression, Option<Cost>)>,
+    /// Physical expression node to id.
+    physical_expr_node_to_id_index: HashMap<PhysicalExpression, PhysicalExpressionId>,
+
+    /// Dependent physical expression ids for each goal id.
+    /// This is used to quickly find all the physical expressions that have a child equal to the goal id, which is the key.
+    /// Dependent here does not mean the dependency stuff that we have in the memo table
+    goal_dependent_physical_exprs: HashMap<GoalId, HashSet<PhysicalExpressionId>>,
+
+    /// Dependent physical expression ids for each physical expression id.
+    /// This is used to quickly find all the physical expressions that have a child equal to the physical expression id, which is the key.
+    physical_expr_dependent_physical_exprs:
+        HashMap<PhysicalExpressionId, HashSet<PhysicalExpressionId>>,
+
+    /// Goal id to state.
+    goals: HashMap<GoalId, GoalState>,
+    /// Goal node to id.
+    goal_node_to_id_index: HashMap<Goal, GoalId>,
+
+    /// A mapping from goal member to the set of goal ids that depend on it.
+    member_subscribers: HashMap<GoalMemberId, HashSet<GoalId>>,
+
+    /// best optimized physical expression for each goal id.
+    best_optimized_physical_expr_index: HashMap<GoalId, (PhysicalExpressionId, Cost)>,
+
+    /// The shared next unique id to be used for goals, groups, logical expressions, and physical expressions.
+    next_shared_id: i64,
+
+    repr_group: UnionFind<GroupId>,
+    repr_goal: UnionFind<GoalId>,
+    repr_logical_expr: UnionFind<LogicalExpressionId>,
+    repr_physical_expr: UnionFind<PhysicalExpressionId>,
+
+    transform_dependency: HashMap<LogicalExpressionId, HashMap<TransformationRule, RuleDependency>>,
+    implement_dependency:
+        HashMap<LogicalExpressionId, HashMap<(GoalId, ImplementationRule), RuleDependency>>,
+    cost_dependency: HashMap<PhysicalExpressionId, CostDependency>,
+}
+
+struct RuleDependency {
+    group_ids: HashSet<GroupId>,
+    status: TaskStatus,
+}
+
+impl RuleDependency {
+    fn new(status: TaskStatus) -> Self {
+        let group_ids = HashSet::new();
+        Self { group_ids, status }
+    }
+}
+
+struct CostDependency {
+    goal_ids: HashSet<GoalId>,
+    status: TaskStatus,
+}
+
+impl CostDependency {
+    fn new(status: TaskStatus) -> Self {
+        let goal_ids = HashSet::new();
+        Self { goal_ids, status }
+    }
+}
+
+/// State of a group in the memo structure.
+struct GroupState {
+    /// The logical properties of the group, might be `None` if it hasn't been derived yet.
+    properties: Option<LogicalProperties>,
+    logical_exprs: HashSet<LogicalExpressionId>,
+    goals: HashSet<GoalId>,
+}
+
+impl GroupState {
+    fn new(logical_expr_id: LogicalExpressionId) -> Self {
+        let mut logical_exprs = HashSet::new();
+        logical_exprs.insert(logical_expr_id);
+        Self {
+            properties: None,
+            logical_exprs,
+            goals: HashSet::new(),
+        }
+    }
+}
+
+struct GoalState {
+    /// The set of members that are part of this goal.
+    goal: Goal,
+    members: HashSet<GoalMemberId>,
+}
+
+impl GoalState {
+    fn new(goal: Goal) -> Self {
+        Self {
+            goal,
+            members: HashSet::new(),
+        }
+    }
+}
+
+impl Representative for MemoryMemo {
+    async fn find_repr_group(&self, group_id: GroupId) -> GroupId {
+        self.repr_group.find(&group_id)
+    }
+
+    async fn find_repr_goal(&self, goal_id: GoalId) -> GoalId {
+        self.repr_goal.find(&goal_id)
+    }
+
+    async fn find_repr_logical_expr(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+    ) -> LogicalExpressionId {
+        self.repr_logical_expr.find(&logical_expr_id)
+    }
+
+    async fn find_repr_physical_expr(
+        &self,
+        physical_expr_id: PhysicalExpressionId,
+    ) -> PhysicalExpressionId {
+        self.repr_physical_expr.find(&physical_expr_id)
+    }
+}
+
+impl Materialize for MemoryMemo {
+    async fn get_goal_id(&mut self, goal: &Goal) -> MemoResult<GoalId> {
+        if let Some(goal_id) = self.goal_node_to_id_index.get(goal).cloned() {
+            return Ok(goal_id);
+        }
+        let goal_id = self.next_goal_id();
+        self.goal_node_to_id_index.insert(goal.clone(), goal_id);
+        self.goals.insert(goal_id, GoalState::new(goal.clone()));
+
+        let Goal(group_id, _) = goal;
+        self.groups.get_mut(group_id).unwrap().goals.insert(goal_id);
+        Ok(goal_id)
+    }
+
+    async fn materialize_goal(&self, goal_id: GoalId) -> MemoResult<Goal> {
+        let state = self
+            .goals
+            .get(&goal_id)
+            .ok_or(MemoError::GoalNotFound(goal_id))?;
+
+        Ok(state.goal.clone())
+    }
+
+    async fn get_logical_expr_id(
+        &mut self,
+        logical_expr: &LogicalExpression,
+    ) -> MemoResult<LogicalExpressionId> {
+        if let Some(logical_expr_id) = self
+            .logical_expr_node_to_id_index
+            .get(logical_expr)
+            .cloned()
+        {
+            return Ok(logical_expr_id);
+        }
+        let logical_expr_id = self.next_logical_expr_id();
+        self.logical_expr_node_to_id_index
+            .insert(logical_expr.clone(), logical_expr_id);
+        self.logical_exprs
+            .insert(logical_expr_id, logical_expr.clone());
+
+        for child in logical_expr.children.iter() {
+            match child {
+                Child::Singleton(group_id) => {
+                    self.group_dependent_logical_exprs
+                        .entry(*group_id)
+                        .or_default()
+                        .insert(logical_expr_id);
+                }
+                Child::VarLength(group_ids) => {
+                    for group_id in group_ids.iter() {
+                        self.group_dependent_logical_exprs
+                            .entry(*group_id)
+                            .or_default()
+                            .insert(logical_expr_id);
+                    }
+                }
+            }
+        }
+        Ok(logical_expr_id)
+    }
+
+    async fn materialize_logical_expr(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+    ) -> MemoResult<LogicalExpression> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let logical_expr = self
+            .logical_exprs
+            .get(&logical_expr_id)
+            .ok_or(MemoError::LogicalExprNotFound(logical_expr_id))?;
+        Ok(logical_expr.clone())
+    }
+
+    async fn get_physical_expr_id(
+        &mut self,
+        physical_expr: &PhysicalExpression,
+    ) -> MemoResult<PhysicalExpressionId> {
+        if let Some(physical_expr_id) = self
+            .physical_expr_node_to_id_index
+            .get(physical_expr)
+            .cloned()
+        {
+            return Ok(physical_expr_id);
+        }
+        let physical_expr_id = self.next_physical_expr_id();
+        self.physical_expr_node_to_id_index
+            .insert(physical_expr.clone(), physical_expr_id);
+        self.physical_exprs
+            .insert(physical_expr_id, (physical_expr.clone(), None));
+
+        for child in physical_expr.children.iter() {
+            match child {
+                Child::Singleton(goal_member_id) => {
+                    if let GoalMemberId::GoalId(goal_id) = goal_member_id {
+                        self.goal_dependent_physical_exprs
+                            .entry(*goal_id)
+                            .or_default()
+                            .insert(physical_expr_id);
+                    }
+                }
+                Child::VarLength(goal_member_ids) => {
+                    for goal_member_id in goal_member_ids.iter() {
+                        match goal_member_id {
+                            GoalMemberId::GoalId(goal_id) => {
+                                self.goal_dependent_physical_exprs
+                                    .entry(*goal_id)
+                                    .or_default()
+                                    .insert(physical_expr_id);
+                            }
+                            GoalMemberId::PhysicalExpressionId(child_physical_expr_id) => {
+                                self.physical_expr_dependent_physical_exprs
+                                    .entry(*child_physical_expr_id)
+                                    .or_default()
+                                    .insert(physical_expr_id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(physical_expr_id)
+    }
+
+    async fn materialize_physical_expr(
+        &self,
+        physical_expr_id: PhysicalExpressionId,
+    ) -> MemoResult<PhysicalExpression> {
+        let physical_expr_id = self.find_repr_physical_expr(physical_expr_id).await;
+        let (physical_expr, _) = self
+            .physical_exprs
+            .get(&physical_expr_id)
+            .ok_or(MemoError::PhysicalExprNotFound(physical_expr_id))?;
+        Ok(physical_expr.clone())
+    }
+}
+
+impl Memo for MemoryMemo {
+    async fn merge_groups(
+        &mut self,
+        group_id_1: GroupId,
+        group_id_2: GroupId,
+    ) -> MemoResult<Option<MergeProducts>> {
+        self.merge_groups_helper(group_id_1, group_id_2).await
+    }
+
+    async fn get_logical_properties(
+        &self,
+        group_id: GroupId,
+    ) -> MemoResult<Option<LogicalProperties>> {
+        let group_id = self.find_repr_group(group_id).await;
+        let group = self
+            .groups
+            .get(&group_id)
+            .ok_or(MemoError::GroupNotFound(group_id))?;
+
+        Ok(group.properties.clone())
+    }
+
+    async fn set_logical_properties(
+        &mut self,
+        group_id: GroupId,
+        props: LogicalProperties,
+    ) -> MemoResult<()> {
+        let group_id = self.find_repr_group(group_id).await;
+        let group = self
+            .groups
+            .get_mut(&group_id)
+            .ok_or(MemoError::GroupNotFound(group_id))?;
+
+        group.properties = Some(props);
+        Ok(())
+    }
+
+    async fn get_all_logical_exprs(
+        &self,
+        group_id: GroupId,
+    ) -> MemoResult<Vec<LogicalExpressionId>> {
+        let group_id = self.find_repr_group(group_id).await;
+        let group = self
+            .groups
+            .get(&group_id)
+            .ok_or(MemoError::GroupNotFound(group_id))?;
+
+        Ok(group.logical_exprs.iter().cloned().collect())
+    }
+
+    async fn get_any_logical_expr(&self, group_id: GroupId) -> MemoResult<LogicalExpressionId> {
+        let group_id = self.find_repr_group(group_id).await;
+        let group = self
+            .groups
+            .get(&group_id)
+            .ok_or(MemoError::GroupNotFound(group_id))?;
+
+        group
+            .logical_exprs
+            .iter()
+            .next()
+            .cloned()
+            .ok_or(MemoError::NoLogicalExprInGroup(group_id))
+    }
+
+    async fn find_logical_expr_group(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+    ) -> MemoResult<Option<GroupId>> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let maybe_group_id = self.logical_expr_group_index.get(&logical_expr_id).cloned();
+        Ok(maybe_group_id)
+    }
+
+    async fn create_group(&mut self, logical_expr_id: LogicalExpressionId) -> MemoResult<GroupId> {
+        let group_id = self.next_group_id();
+        let group = GroupState::new(logical_expr_id);
+        self.groups.insert(group_id, group);
+        self.logical_expr_group_index
+            .insert(logical_expr_id, group_id);
+
+        Ok(group_id)
+    }
+
+    async fn get_best_optimized_physical_expr(
+        &self,
+        goal_id: GoalId,
+    ) -> MemoResult<Option<(PhysicalExpressionId, Cost)>> {
+        let goal_id = self.find_repr_goal(goal_id).await;
+        let maybe_best_costed = self
+            .best_optimized_physical_expr_index
+            .get(&goal_id)
+            .cloned();
+        Ok(maybe_best_costed)
+    }
+
+    async fn get_all_goal_members(&self, goal_id: GoalId) -> MemoResult<Vec<GoalMemberId>> {
+        let goal_id = self.find_repr_goal(goal_id).await;
+        let goal_state = self.goals.get(&goal_id).unwrap();
+        Ok(goal_state.members.iter().cloned().collect())
+    }
+
+    async fn add_goal_member(
+        &mut self,
+        goal_id: GoalId,
+        member: GoalMemberId,
+    ) -> MemoResult<Option<PropagateBestExpression>> {
+        let goal_id = self.find_repr_goal(goal_id).await;
+        let member = self.find_repr_goal_member(member).await?;
+        let goal_state = self.goals.get_mut(&goal_id).unwrap();
+
+        let is_new = goal_state.members.insert(member);
+        if is_new {
+            // Create a new subscriber for the member (initialize the set if it doesn't exist).
+            self.member_subscribers
+                .entry(member)
+                .or_default()
+                .insert(goal_id);
+
+            let new_member_cost = match member {
+                GoalMemberId::PhysicalExpressionId(physical_expr_id) => self
+                    .get_physical_expr_cost(physical_expr_id)
+                    .await?
+                    .map(|c| (physical_expr_id, c)),
+                GoalMemberId::GoalId(member_goal_id) => {
+                    self.get_best_optimized_physical_expr(member_goal_id)
+                        .await?
+                }
+            };
+
+            let mut subscribers = VecDeque::new();
+            subscribers.push_back(goal_id);
+
+            let Some((physical_expr_id, cost)) = new_member_cost else {
+                return Ok(None);
+            };
+            let mut subscribers = VecDeque::new();
+            subscribers.push_back(goal_id);
+            let mut result = PropagateBestExpression::new(physical_expr_id, cost);
+            // propagate the new cost to all subscribers.
+            self.propagate_new_member_cost(subscribers, &mut result)
+                .await?;
+            if result.goals_propagated_to.is_empty() {
+                // No goals were forwarded, so we can return None.
+                Ok(None)
+            } else {
+                // Some goals were forwarded, so we return the result.
+                Ok(Some(result))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn get_physical_expr_cost(
+        &self,
+        physical_expr_id: PhysicalExpressionId,
+    ) -> MemoResult<Option<Cost>> {
+        let physical_expr_id = self.find_repr_physical_expr(physical_expr_id).await;
+        let (_, maybe_cost) = self
+            .physical_exprs
+            .get(&physical_expr_id)
+            .ok_or(MemoError::PhysicalExprNotFound(physical_expr_id))?;
+        Ok(*maybe_cost)
+    }
+
+    async fn update_physical_expr_cost(
+        &mut self,
+        physical_expr_id: PhysicalExpressionId,
+        new_cost: Cost,
+    ) -> MemoResult<Option<PropagateBestExpression>> {
+        let physical_expr_id = self.find_repr_physical_expr(physical_expr_id).await;
+        let (_, cost_mut) = self
+            .physical_exprs
+            .get_mut(&physical_expr_id)
+            .ok_or(MemoError::PhysicalExprNotFound(physical_expr_id))?;
+        let is_better = cost_mut
+            .replace(new_cost)
+            .map(|old_cost| new_cost < old_cost)
+            .unwrap_or(true);
+
+        if is_better {
+            let mut subscribers = VecDeque::new();
+            // keep propagating the new cost to all subscribers.
+            if let Some(subscriber_goal_ids) = self
+                .member_subscribers
+                .get(&GoalMemberId::PhysicalExpressionId(physical_expr_id))
+                .map(|goals| goals.iter().cloned())
+            {
+                subscribers.extend(subscriber_goal_ids);
+            }
+
+            let mut result = PropagateBestExpression::new(physical_expr_id, new_cost);
+            // propagate the new cost to all subscribers.
+            self.propagate_new_member_cost(subscribers, &mut result)
+                .await?;
+            if result.goals_propagated_to.is_empty() {
+                // No goals were forwarded, so we can return None.
+                Ok(None)
+            } else {
+                // Some goals were forwarded, so we return the result.
+                Ok(Some(result))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl MemoryMemo {
+    /// Creates a new logical expression with the same children but with the children being the representative group ids.
+    async fn create_repr_logical_expr(
+        &mut self,
+        logical_expr: LogicalExpression,
+    ) -> MemoResult<LogicalExpression> {
+        let mut repr_logical_expr = logical_expr.clone();
+        let mut new_children = Vec::new();
+
+        for child in repr_logical_expr.children.iter() {
+            match child {
+                Child::Singleton(group_id) => {
+                    let repr_group_id = self.find_repr_group(*group_id).await;
+                    new_children.push(Child::Singleton(repr_group_id));
+                }
+                Child::VarLength(group_ids) => {
+                    let new_group_ids = group_ids
+                        .iter()
+                        .map(|group_id| {
+                            let self_ref = &self;
+                            // TODO(Sarvesh): this is a hack to get the repr group id, i'm sure there's a better way to do this.
+                            async move { self_ref.find_repr_group(*group_id).await }
+                        })
+                        .collect::<Vec<_>>();
+
+                    let new_group_ids = futures::future::join_all(new_group_ids)
+                        .await
+                        .into_iter()
+                        .collect();
+
+                    new_children.push(Child::VarLength(new_group_ids));
+                }
+            }
+        }
+        repr_logical_expr.children = new_children;
+        Ok(repr_logical_expr)
+    }
+
+    /// Creates a new physical expression with the same children but with the children being the representative group ids.
+    async fn create_repr_physical_expr(
+        &mut self,
+        physical_expr: PhysicalExpression,
+    ) -> MemoResult<PhysicalExpression> {
+        let mut repr_physical_expr = physical_expr.clone();
+        let mut new_children = Vec::new();
+
+        for child in repr_physical_expr.children.iter() {
+            match child {
+                Child::Singleton(goal_member_id) => {
+                    if let GoalMemberId::GoalId(goal_id) = goal_member_id {
+                        let repr_goal_id = self.find_repr_goal(*goal_id).await;
+                        new_children.push(Child::Singleton(GoalMemberId::GoalId(repr_goal_id)));
+                    } else {
+                        new_children.push(Child::Singleton(*goal_member_id));
+                    }
+                }
+                Child::VarLength(goal_member_ids) => {
+                    let mut new_goal_member_ids = Vec::new();
+                    for goal_member_id in goal_member_ids.iter() {
+                        match goal_member_id {
+                            GoalMemberId::GoalId(goal_id) => {
+                                let repr_goal_id = self.find_repr_goal(*goal_id).await;
+                                new_goal_member_ids.push(GoalMemberId::GoalId(repr_goal_id));
+                            }
+                            GoalMemberId::PhysicalExpressionId(physical_expr_id) => {
+                                let repr_physical_expr_id =
+                                    self.find_repr_physical_expr(*physical_expr_id).await;
+                                new_goal_member_ids.push(GoalMemberId::PhysicalExpressionId(
+                                    repr_physical_expr_id,
+                                ));
+                            }
+                        }
+                    }
+                    new_children.push(Child::VarLength(new_goal_member_ids));
+                }
+            }
+        }
+        repr_physical_expr.children = new_children;
+        Ok(repr_physical_expr)
+    }
+
+    /// Recursively merges physical expressions.
+    #[async_recursion]
+    async fn merge_physical_exprs(
+        &mut self,
+        physical_expr_id: PhysicalExpressionId,
+    ) -> MemoResult<Vec<PhysicalMergeProduct>> {
+        let (physical_expr, _cost) = self.physical_exprs.get(&physical_expr_id).unwrap();
+        let repr_physical_expr = self
+            .create_repr_physical_expr(physical_expr.clone())
+            .await?;
+        let repr_physical_expr_id = self.get_physical_expr_id(&repr_physical_expr).await?;
+
+        // merge the physical exprs
+        self.repr_physical_expr
+            .merge(&physical_expr_id, &repr_physical_expr_id);
+
+        let subscribers = self
+            .member_subscribers
+            .remove(&GoalMemberId::PhysicalExpressionId(physical_expr_id));
+        if let Some(subscribers) = subscribers {
+            // add the subscribers to the repr physical expr id
+            self.member_subscribers
+                .entry(GoalMemberId::PhysicalExpressionId(repr_physical_expr_id))
+                .or_default()
+                .extend(subscribers);
+        }
+
+        let mut results = Vec::new();
+        results.push(PhysicalMergeProduct {
+            repr_physical_expr: repr_physical_expr_id,
+            non_repr_physical_exprs: physical_expr_id,
+        });
+
+        let dependent_physical_exprs = self
+            .physical_expr_dependent_physical_exprs
+            .get(&physical_expr_id);
+        if let Some(dependent_physical_exprs) = dependent_physical_exprs {
+            let dependent_physical_exprs =
+                dependent_physical_exprs.iter().cloned().collect::<Vec<_>>();
+            for dependent_physical_expr_id in dependent_physical_exprs {
+                // TODO(Sarvesh): handle async recursion
+                let merge_physical_expr_result = self
+                    .merge_physical_exprs(dependent_physical_expr_id)
+                    .await?;
+                results.extend(merge_physical_expr_result);
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Merges two goals into a single goal.
+    async fn merge_goals_helper(
+        &mut self,
+        goal_id1: GoalId,
+        goal_id2: GoalId,
+    ) -> MemoResult<(GoalMergeProduct, Vec<PhysicalMergeProduct>)> {
+        let goal_2 = self.goals.remove(&goal_id2).unwrap();
+        let goal_1 = self.goals.get(&goal_id1).unwrap();
+
+        self.repr_goal.merge(&goal_id2, &goal_id1);
+
+        let mut merged_goal_result = GoalMergeProduct {
+            best_expr: None,
+            repr_goal_id: goal_id1,
+            non_repr_goal_id: goal_id2,
+            repr_goal_seen_best_expr_before_merge: false,
+            non_repr_goal_seen_best_expr_before_merge: false,
+            members: HashSet::default(),
+        };
+
+        let best_expr_goal1 = self.get_best_optimized_physical_expr(goal_id1).await?;
+        let best_expr_goal2 = self.get_best_optimized_physical_expr(goal_id2).await?;
+
+        let best_expr = match (best_expr_goal1, best_expr_goal2) {
+            (Some(best_expr_goal1), Some(best_expr_goal2)) => {
+                Some(if best_expr_goal1.1 < best_expr_goal2.1 {
+                    best_expr_goal1
+                } else {
+                    best_expr_goal2
+                })
+            }
+            (Some(best_expr_goal1), None) => Some(best_expr_goal1),
+            (None, Some(best_expr_goal2)) => Some(best_expr_goal2),
+            (None, None) => None,
+        };
+
+        if let Some(best_expr) = best_expr {
+            merged_goal_result.best_expr = Some(best_expr);
+        }
+
+        merged_goal_result.repr_goal_seen_best_expr_before_merge = {
+            if let Some(best_expr_goal1) = best_expr_goal1 {
+                if let Some(best_expr_goal2) = best_expr_goal2 {
+                    // goal 1 and goal 2 both had expr, return true if goal 1's is better or equal to goal 2's
+                    best_expr_goal1.1 <= best_expr_goal2.1
+                } else {
+                    // goal 1 had a best expr before merge but goal 2 didn't
+                    true
+                }
+            } else {
+                // neither goal had a best expr before merge
+                false
+            }
+        };
+
+        merged_goal_result.non_repr_goal_seen_best_expr_before_merge = {
+            if let Some(best_expr_goal2) = best_expr_goal2 {
+                if let Some(best_expr_goal1) = best_expr_goal1 {
+                    // goal 2 and goal 1 both had expr, return true if goal 2's is better or equal to goal 1's
+                    best_expr_goal2.1 <= best_expr_goal1.1
+                } else {
+                    // goal 2 had a best expr before merge but goal 1 didn't
+                    true
+                }
+            } else {
+                // neither goal had a best expr before merge
+                false
+            }
+        };
+
+        merged_goal_result.members = goal_1.members.iter().cloned().collect();
+        merged_goal_result
+            .members
+            .extend(goal_2.members.iter().cloned());
+
+        let forward_result = self
+            .add_goal_member(goal_id1, GoalMemberId::GoalId(goal_id2))
+            .await?;
+        if let Some(forward_result) = forward_result {
+            // change the subscribers of goal 2 to now be subscribed to goal 1
+            let subscribers = self
+                .member_subscribers
+                .remove(&GoalMemberId::GoalId(goal_id2));
+            if let Some(subscribers) = subscribers {
+                self.member_subscribers
+                    .entry(GoalMemberId::GoalId(goal_id1))
+                    .or_default()
+                    .extend(&subscribers);
+                let mut temp_forward_result = PropagateBestExpression::new(
+                    forward_result.physical_expr_id,
+                    forward_result.best_cost,
+                );
+                let vec_deque_subscribers =
+                    VecDeque::from(subscribers.into_iter().collect::<Vec<_>>());
+                self.propagate_new_member_cost(vec_deque_subscribers, &mut temp_forward_result)
+                    .await?;
+            }
+        }
+
+        // Now, we need to update all the physical exprs that depend on goal 2 to now depend on goal 1.
+        let goal_2_dependent_physical_exprs =
+            match self.goal_dependent_physical_exprs.get(&goal_id2) {
+                None => HashSet::default(),
+                Some(exprs) => exprs.clone(),
+            };
+
+        let mut results = Vec::new();
+        for physical_expr_id in goal_2_dependent_physical_exprs {
+            let merge_physical_expr_result = self.merge_physical_exprs(physical_expr_id).await?;
+            results.extend(merge_physical_expr_result);
+        }
+
+        Ok((merged_goal_result, results))
+    }
+
+    #[async_recursion]
+    async fn merge_groups_helper(
+        &mut self,
+        group_id_1: GroupId,
+        group_id_2: GroupId,
+    ) -> MemoResult<Option<MergeProducts>> {
+        // our strategy is to always merge group 2 into group 1.
+        let group_id_1 = self.find_repr_group(group_id_1).await;
+        let group_id_2 = self.find_repr_group(group_id_2).await;
+
+        if group_id_1 == group_id_2 {
+            return Ok(None);
+        }
+        let mut result = MergeProducts::default();
+        let group_2_state = self.groups.remove(&group_id_2).unwrap();
+        let group_2_exprs: Vec<LogicalExpressionId> =
+            group_2_state.logical_exprs.iter().cloned().collect();
+
+        let group1_state = self.groups.get_mut(&group_id_1).unwrap();
+        let group1_exprs: Vec<LogicalExpressionId> =
+            group1_state.logical_exprs.iter().cloned().collect();
+
+        for logical_expr_id in group_2_state.logical_exprs {
+            // Update the logical expression to point to the new group id.
+            let old_group_id = self
+                .logical_expr_group_index
+                .insert(logical_expr_id, group_id_1);
+            assert!(old_group_id.is_some());
+            group1_state.logical_exprs.insert(logical_expr_id);
+        }
+        let mut merge_group_result = GroupMergeProduct::new(group_id_1, group_id_2);
+        merge_group_result
+            .all_exprs_in_merged_group
+            .extend(group1_exprs.iter().cloned());
+        merge_group_result
+            .all_exprs_in_merged_group
+            .extend(group_2_exprs.iter().cloned());
+
+        self.repr_group.merge(&group_id_2, &group_id_1);
+
+        merge_group_result.repr_group_exprs.extend(group1_exprs);
+        merge_group_result
+            .non_repr_group_exprs
+            .extend(group_2_exprs);
+
+        result.group_merges.push(merge_group_result);
+
+        // So now, we have to find out all the goals that belong to both groups but contain the same properties.
+
+        let group_1_goals = group1_state.goals.iter().cloned().collect::<HashSet<_>>();
+        let group_2_goals = group_2_state.goals.iter().cloned().collect::<HashSet<_>>();
+
+        for goal_id1 in group_1_goals.iter() {
+            for goal_id2 in group_2_goals.iter() {
+                let goal_1 = self.goals.get(goal_id1).unwrap();
+                let goal_2 = self.goals.get(goal_id2).unwrap();
+                let goal_1_props = &goal_1.goal.1;
+                let goal_2_props = &goal_2.goal.1;
+                if goal_1_props == goal_2_props {
+                    let (merged_goal_result, merge_physical_expr_results) =
+                        self.merge_goals_helper(*goal_id1, *goal_id2).await?;
+                    result.goal_merges.push(merged_goal_result);
+                    result
+                        .physical_expr_merges
+                        .extend(merge_physical_expr_results);
+                }
+            }
+        }
+
+        // Let's check for cascading merges now.
+        let logical_expr_with_group_2_as_child =
+            match self.group_dependent_logical_exprs.get(&group_id_2) {
+                None => HashSet::default(),
+                Some(exprs) => exprs.clone(),
+            };
+
+        for logical_expr_id in logical_expr_with_group_2_as_child.iter() {
+            let logical_expr = self.logical_exprs.get(logical_expr_id).unwrap();
+            let repr_logical_expr = self.create_repr_logical_expr(logical_expr.clone()).await?;
+            let repr_logical_expr_id = self.get_logical_expr_id(&repr_logical_expr).await?;
+            // merge the logical exprs
+            self.repr_logical_expr
+                .merge(logical_expr_id, &repr_logical_expr_id);
+
+            let parent_group_id = self.logical_expr_group_index.get(logical_expr_id).unwrap();
+            let parent_group_state = self.groups.get_mut(parent_group_id).unwrap();
+            // We remove the stale logical expr from the parent group.
+            parent_group_state.logical_exprs.remove(logical_expr_id);
+
+            // is the repr logical expr already part of a group?
+            if let Some(repr_parent_group_id) =
+                self.logical_expr_group_index.get(&repr_logical_expr_id)
+            {
+                // the repr logical expr is part of a group, so
+                let parent_group_id = self.logical_expr_group_index.get(logical_expr_id).unwrap();
+                if repr_parent_group_id != parent_group_id {
+                    // we have another merge to do
+                    // do a cascading merge between repr_parent_group_id and parent_group_id
+                    let merge_result = self
+                        .merge_groups_helper(*repr_parent_group_id, *parent_group_id)
+                        .await?;
+                    // merge the cascading merge result with the current result.
+                    if let Some(merge_result) = merge_result {
+                        result.group_merges.extend(merge_result.group_merges);
+                        result
+                            .physical_expr_merges
+                            .extend(merge_result.physical_expr_merges);
+                        result.goal_merges.extend(merge_result.goal_merges);
+                    }
+                }
+            } else {
+                // the repr logical expr is not part of a group, so we add it to the parent group.
+                // We add the new repr logical expr to the parent group.
+                parent_group_state
+                    .logical_exprs
+                    .insert(repr_logical_expr_id);
+                // we update the index
+                self.logical_expr_group_index
+                    .insert(repr_logical_expr_id, *parent_group_id);
+            }
+        }
+
+        Ok(Some(result))
+    }
+
+    /// Generates a new group id.
+    fn next_group_id(&mut self) -> GroupId {
+        let group_id = GroupId(self.next_shared_id);
+        self.next_shared_id += 1;
+        group_id
+    }
+
+    /// Generates a new physical expression id.
+    fn next_physical_expr_id(&mut self) -> PhysicalExpressionId {
+        let physical_expr_id = PhysicalExpressionId(self.next_shared_id);
+        self.next_shared_id += 1;
+        physical_expr_id
+    }
+
+    /// Generates a new logical expression id.
+    fn next_logical_expr_id(&mut self) -> LogicalExpressionId {
+        let logical_expr_id = LogicalExpressionId(self.next_shared_id);
+        self.next_shared_id += 1;
+        logical_expr_id
+    }
+
+    /// Generates a new goal id.
+    fn next_goal_id(&mut self) -> GoalId {
+        let goal_id = GoalId(self.next_shared_id);
+        self.next_shared_id += 1;
+        goal_id
+    }
+
+    /// Propagates the new costed member physical expression to all subscribers.
+    async fn propagate_new_member_cost(
+        &mut self,
+        mut subscribers: VecDeque<GoalId>,
+        result: &mut PropagateBestExpression,
+    ) -> MemoResult<()> {
+        while let Some(goal_id) = subscribers.pop_front() {
+            let current_best = self.get_best_optimized_physical_expr(goal_id).await?;
+
+            let is_better = current_best
+                .map(|(_, cost)| result.best_cost < cost)
+                .unwrap_or(true);
+
+            if is_better {
+                // Update the best cost for the goal.
+                self.best_optimized_physical_expr_index
+                    .insert(goal_id, (result.physical_expr_id, result.best_cost));
+
+                result.goals_propagated_to.insert(goal_id);
+
+                // keep propagating the new cost to all subscribers.
+                if let Some(subscriber_goal_ids) = self
+                    .member_subscribers
+                    .get(&GoalMemberId::GoalId(goal_id))
+                    .map(|goals| goals.iter().cloned().collect::<Vec<_>>())
+                {
+                    for subscriber_goal_id in subscriber_goal_ids {
+                        subscribers.push_back(subscriber_goal_id);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Find the representative of a goal member.
+    ///
+    /// This reduces down to finding representative physical expr or goal id.
+    async fn find_repr_goal_member(&self, member: GoalMemberId) -> MemoResult<GoalMemberId> {
+        match member {
+            GoalMemberId::PhysicalExpressionId(physical_expr_id) => {
+                let physical_expr_id = self.find_repr_physical_expr(physical_expr_id).await;
+                Ok(GoalMemberId::PhysicalExpressionId(physical_expr_id))
+            }
+            GoalMemberId::GoalId(goal_id) => {
+                let goal_id = self.find_repr_goal(goal_id).await;
+                Ok(GoalMemberId::GoalId(goal_id))
+            }
+        }
+    }
+}
+
+impl TaskGraphState for MemoryMemo {
+    async fn get_transformation_status(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+        rule: &TransformationRule,
+    ) -> MemoResult<TaskStatus> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let status = self
+            .transform_dependency
+            .get(&logical_expr_id)
+            .and_then(|status_map| status_map.get(rule))
+            .map(|dep| dep.status)
+            .unwrap_or(TaskStatus::Dirty);
+        Ok(status)
+    }
+
+    async fn set_transformation_clean(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        rule: &TransformationRule,
+    ) -> MemoResult<()> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let status_map = self
+            .transform_dependency
+            .entry(logical_expr_id)
+            .or_default();
+        match status_map.entry(rule.clone()) {
+            Entry::Occupied(occupied_entry) => {
+                let dep = occupied_entry.into_mut();
+                dep.status = TaskStatus::Clean;
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(RuleDependency::new(TaskStatus::Clean));
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_implementation_status(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+        goal_id: GoalId,
+        rule: &ImplementationRule,
+    ) -> MemoResult<TaskStatus> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let goal_id = self.find_repr_goal(goal_id).await;
+        let status = self
+            .implement_dependency
+            .get(&logical_expr_id)
+            .and_then(|status_map| status_map.get(&(goal_id, rule.clone())))
+            .map(|dep| dep.status)
+            .unwrap_or(TaskStatus::Dirty);
+        Ok(status)
+    }
+
+    async fn set_implementation_clean(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        goal_id: GoalId,
+        rule: &ImplementationRule,
+    ) -> MemoResult<()> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let status_map = self
+            .implement_dependency
+            .entry(logical_expr_id)
+            .or_default();
+        match status_map.entry((goal_id, rule.clone())) {
+            Entry::Occupied(occupied_entry) => {
+                let dep = occupied_entry.into_mut();
+                dep.status = TaskStatus::Clean;
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(RuleDependency::new(TaskStatus::Clean));
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_cost_status(
+        &self,
+        physical_expr_id: PhysicalExpressionId,
+    ) -> MemoResult<TaskStatus> {
+        let physical_expr_id = self.find_repr_physical_expr(physical_expr_id).await;
+        let status = self
+            .cost_dependency
+            .get(&physical_expr_id)
+            .map(|dep| dep.status)
+            .unwrap_or(TaskStatus::Dirty);
+        Ok(status)
+    }
+
+    async fn set_cost_clean(&mut self, physical_expr_id: PhysicalExpressionId) -> MemoResult<()> {
+        let physical_expr_id = self.find_repr_physical_expr(physical_expr_id).await;
+
+        let entry = self.cost_dependency.entry(physical_expr_id);
+
+        match entry {
+            Entry::Occupied(occupied) => {
+                let dep = occupied.into_mut();
+                dep.status = TaskStatus::Clean;
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(CostDependency::new(TaskStatus::Clean));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn add_transformation_dependency(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        rule: &TransformationRule,
+        group_id: GroupId,
+    ) -> MemoResult<()> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let group_id = self.find_repr_group(group_id).await;
+        let status_map = self
+            .transform_dependency
+            .entry(logical_expr_id)
+            .or_default();
+
+        match status_map.entry(rule.clone()) {
+            Entry::Occupied(occupied_entry) => {
+                let dep = occupied_entry.into_mut();
+                dep.group_ids.insert(group_id);
+            }
+            Entry::Vacant(vacant) => {
+                let mut dep = RuleDependency::new(TaskStatus::Dirty);
+                dep.group_ids.insert(group_id);
+                vacant.insert(dep);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn add_implementation_dependency(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        goal_id: GoalId,
+        rule: &ImplementationRule,
+        group_id: GroupId,
+    ) -> MemoResult<()> {
+        let logical_expr_id = self.find_repr_logical_expr(logical_expr_id).await;
+        let group_id = self.find_repr_group(group_id).await;
+        let goal_id = self.find_repr_goal(goal_id).await;
+
+        let status_map = self
+            .implement_dependency
+            .entry(logical_expr_id)
+            .or_default();
+
+        match status_map.entry((goal_id, rule.clone())) {
+            Entry::Occupied(occupied) => {
+                let dep = occupied.into_mut();
+                dep.group_ids.insert(group_id);
+            }
+            Entry::Vacant(vacant) => {
+                let mut dep = RuleDependency::new(TaskStatus::Dirty);
+                dep.group_ids.insert(group_id);
+                vacant.insert(dep);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn add_cost_dependency(
+        &mut self,
+        physical_expr_id: PhysicalExpressionId,
+        goal_id: GoalId,
+    ) -> MemoResult<()> {
+        let physical_expr_id = self.find_repr_physical_expr(physical_expr_id).await;
+        let goal_id = self.find_repr_goal(goal_id).await;
+
+        match self.cost_dependency.entry(physical_expr_id) {
+            Entry::Occupied(occupied) => {
+                let dep = occupied.into_mut();
+                dep.goal_ids.insert(goal_id);
+            }
+            Entry::Vacant(vacant) => {
+                let mut dep = CostDependency::new(TaskStatus::Dirty);
+                dep.goal_ids.insert(goal_id);
+                vacant.insert(dep);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/optd/src/memo/mod.rs
+++ b/optd/src/memo/mod.rs
@@ -1,3 +1,18 @@
-mod errors;
-mod merge_repr;
+/// Error and Result definitions.
+mod error;
+pub use error::*;
+
+/// Type definitions.
+mod types;
+pub use types::*;
+
+/// Trait definitions.
 mod traits;
+pub use traits::*;
+
+/// A generic implementation of the Union-Find algorithm.
+mod union_find;
+pub use union_find::*;
+
+/// In-memory implementation of the memo table and task graph state.
+pub mod memory;

--- a/optd/src/memo/traits.rs
+++ b/optd/src/memo/traits.rs
@@ -1,78 +1,89 @@
-use crate::cir::{
-    Cost, Goal, GoalId, GoalMemberId, GroupId, LogicalExpression, LogicalExpressionId,
-    LogicalProperties, PhysicalExpression, PhysicalExpressionId,
-};
+use super::{MemoResult, MergeProducts, PropagateBestExpression, TaskStatus};
+use crate::cir::*;
 
-use super::errors::MemoError;
-
-/// Type alias for results returned by Memo trait methods.
-pub type MemoResult<T> = Result<T, MemoError>;
-
-/// Information about a merged group, including its ID and expressions.
-#[derive(Debug)]
-pub struct MergedGroupInfo {
-    /// ID of the merged group.
-    pub group_id: GroupId,
-
-    /// All logical expressions in this group.
-    pub expressions: Vec<LogicalExpressionId>,
-}
-
-/// Result of merging two groups.
-#[derive(Debug)]
-pub struct MergeGroupResult {
-    /// Groups that were merged along with their expressions.
-    pub merged_groups: Vec<MergedGroupInfo>,
-
-    /// ID of the new representative group id.
-    pub new_repr_group_id: GroupId,
-}
-
-/// Information about a merged goal, including its ID and expressions.
-#[derive(Debug)]
-pub struct MergedGoalInfo {
-    /// ID of the merged goal.
-    pub goal_id: GoalId,
-
-    /// The best costed expression for this goal, if any.
-    pub best_expr: Option<(PhysicalExpressionId, Cost)>,
-
-    /// All members in this goal, which can be physical expressions or references to other goals.
-    pub members: Vec<GoalMemberId>,
-}
-
-/// Result of merging two goals.
-#[derive(Debug)]
-pub struct MergeGoalResult {
-    /// Goals that were merged along with their potential best costed expression.
-    pub merged_goals: Vec<MergedGoalInfo>,
-
-    /// ID of the new representative goal id.
-    pub new_repr_goal_id: GoalId,
-}
-
-/// Results of merge operations with newly dirtied expressions.
-#[derive(Debug)]
-pub struct MergeResult {
-    /// Group merge results.
-    pub group_merges: Vec<MergeGroupResult>,
-
-    /// Goal merge results.
-    pub goal_merges: Vec<MergeGoalResult>,
-}
-
-/// Core interface for memo-based query optimization.
-///
-/// This trait defines the operations needed to store, retrieve, and manipulate
-/// the memo data structure that powers the dynamic programming approach to
-/// query optimization. The memo stores logical and physical expressions by their IDs,
-/// manages expression properties, and tracks optimization status.
+/// A helper trait to help facilitate finding the representative IDs of elements.
 #[trait_variant::make(Send)]
-pub trait Memo: Send + Sync + 'static {
-    //
-    // Logical expression and group operations.
-    //
+pub trait Representative {
+    /// Finds the representative group of a given group. The representative is usually tracked via a
+    /// Union-Find data structure.
+    ///
+    /// If the input group is already the representative, then the returned [`GroupId`] is equal to
+    /// the input [`GroupId`].
+    async fn find_repr_group(&self, group_id: GroupId) -> GroupId;
 
+    /// Finds the representative goal of a given goal. The representative is usually tracked via a
+    /// Union-Find data structure.
+    ///
+    /// If the input goal is already the representative, then the returned [`GoalId`] is equal to
+    /// the input [`GoalId`].
+    async fn find_repr_goal(&self, goal_id: GoalId) -> GoalId;
+
+    /// Finds the representative logical expression of a given expression. The representative is
+    /// usually tracked via a Union-Find data structure.
+    ///
+    /// If the input expression is already the representative, then the returned
+    /// [`LogicalExpressionId`] is equal to the input [`LogicalExpressionId`].
+    async fn find_repr_logical_expr(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+    ) -> LogicalExpressionId;
+
+    /// Finds the representative physical expression of a given expression. The representative is
+    /// usually tracked via a Union-Find data structure.
+    ///
+    /// If the input expression is already the representative, then the returned
+    /// [`PhysicalExpressionId`] is equal to the input [`PhysicalExpressionId`].
+    async fn find_repr_physical_expr(
+        &self,
+        physical_expr_id: PhysicalExpressionId,
+    ) -> PhysicalExpressionId;
+}
+
+/// A helper trait to help facilitate the materialization and creation of objects in the memo table.
+#[trait_variant::make(Send)]
+pub trait Materialize {
+    /// Retrieves the ID of a [`Goal`]. If the [`Goal`] does not already exist in the memo table,
+    /// creates a new [`Goal`] and returns a fresh [`GoalId`].
+    async fn get_goal_id(&mut self, goal: &Goal) -> MemoResult<GoalId>;
+
+    /// Materializes a [`Goal`] from its [`GoalId`].
+    async fn materialize_goal(&self, goal_id: GoalId) -> MemoResult<Goal>;
+
+    /// Retrieves the ID of a [`LogicalExpression`]. If the [`LogicalExpression`] does not already
+    /// exist in the memo table, creates a new [`LogicalExpression`] and returns a fresh
+    /// [`LogicalExpressionId`].
+    async fn get_logical_expr_id(
+        &mut self,
+        logical_expr: &LogicalExpression,
+    ) -> MemoResult<LogicalExpressionId>;
+
+    /// Materializes a [`LogicalExpression`] from its [`LogicalExpressionId`].
+    async fn materialize_logical_expr(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+    ) -> MemoResult<LogicalExpression>;
+
+    /// Retrieves the ID of a [`PhysicalExpression`]. If the [`PhysicalExpression`] does not already
+    /// exist in the memo table, creates a new [`PhysicalExpression`] and returns a fresh
+    /// [`PhysicalExpressionId`].
+    async fn get_physical_expr_id(
+        &mut self,
+        physical_expr: &PhysicalExpression,
+    ) -> MemoResult<PhysicalExpressionId>;
+
+    /// Materializes a [`PhysicalExpression`] from its [`PhysicalExpressionId`].
+    async fn materialize_physical_expr(
+        &self,
+        physical_expr_id: PhysicalExpressionId,
+    ) -> MemoResult<PhysicalExpression>;
+}
+
+/// The interface for an optimizer memoization (memo) table.
+///
+/// This trait mainly describes operations related to groups, goals, logical and physical
+/// expressions, and finding representative nodes of the union-find substructures.
+#[trait_variant::make(Send)]
+pub trait Memo: Representative + Materialize + TaskGraphState + Sync + 'static {
     /// Retrieves logical properties for a group ID.
     ///
     /// # Parameters
@@ -80,7 +91,24 @@ pub trait Memo: Send + Sync + 'static {
     ///
     /// # Returns
     /// The properties associated with the group or an error if not found.
-    async fn get_logical_properties(&self, group_id: GroupId) -> MemoResult<LogicalProperties>;
+    async fn get_logical_properties(
+        &self,
+        group_id: GroupId,
+    ) -> MemoResult<Option<LogicalProperties>>;
+
+    /// Sets logical properties for a group ID.
+    ///
+    /// # Parameters
+    /// * `group_id` - ID of the group to set properties for.
+    /// * `props` - The logical properties to associate with the group.
+    ///
+    /// # Returns
+    /// A result indicating success or failure of the operation.
+    async fn set_logical_properties(
+        &mut self,
+        group_id: GroupId,
+        props: LogicalProperties,
+    ) -> MemoResult<()>;
 
     /// Gets all logical expression IDs in a group (only representative IDs).
     ///
@@ -93,6 +121,9 @@ pub trait Memo: Send + Sync + 'static {
         &self,
         group_id: GroupId,
     ) -> MemoResult<Vec<LogicalExpressionId>>;
+
+    /// Gets any logical expression ID in a group.
+    async fn get_any_logical_expr(&self, group_id: GroupId) -> MemoResult<LogicalExpressionId>;
 
     /// Finds group containing a logical expression ID, if it exists.
     ///
@@ -114,11 +145,7 @@ pub trait Memo: Send + Sync + 'static {
     ///
     /// # Returns
     /// The ID of the newly created group.
-    async fn create_group(
-        &mut self,
-        logical_expr_id: LogicalExpressionId,
-        props: &LogicalProperties,
-    ) -> MemoResult<GroupId>;
+    async fn create_group(&mut self, logical_expr_id: LogicalExpressionId) -> MemoResult<GroupId>;
 
     /// Merges groups 1 and 2, unifying them under a common representative.
     ///
@@ -135,7 +162,7 @@ pub trait Memo: Send + Sync + 'static {
         &mut self,
         group_id_1: GroupId,
         group_id_2: GroupId,
-    ) -> MemoResult<MergeResult>;
+    ) -> MemoResult<Option<MergeProducts>>;
 
     //
     // Physical expression and goal operations.
@@ -154,18 +181,6 @@ pub trait Memo: Send + Sync + 'static {
         goal_id: GoalId,
     ) -> MemoResult<Option<(PhysicalExpressionId, Cost)>>;
 
-    /// Gets all physical expression IDs in a goal (only representative IDs).
-    ///
-    /// # Parameters
-    /// * `goal_id` - ID of the goal to retrieve expressions from.
-    ///
-    /// # Returns
-    /// A vector of physical expression IDs in the specified goal.
-    async fn get_all_physical_exprs(
-        &self,
-        goal_id: GoalId,
-    ) -> MemoResult<Vec<PhysicalExpressionId>>;
-
     /// Gets all members of a goal, which can be physical expressions or other goals.
     ///
     /// # Parameters
@@ -183,7 +198,11 @@ pub trait Memo: Send + Sync + 'static {
     ///
     /// # Returns
     /// True if the member was added to the goal, or false if it already existed.
-    async fn add_goal_member(&mut self, goal_id: GoalId, member: GoalMemberId) -> MemoResult<bool>;
+    async fn add_goal_member(
+        &mut self,
+        goal_id: GoalId,
+        member: GoalMemberId,
+    ) -> MemoResult<Option<PropagateBestExpression>>;
 
     /// Updates the cost of a physical expression ID.
     ///
@@ -197,125 +216,140 @@ pub trait Memo: Send + Sync + 'static {
         &mut self,
         physical_expr_id: PhysicalExpressionId,
         new_cost: Cost,
-    ) -> MemoResult<bool>;
+    ) -> MemoResult<Option<PropagateBestExpression>>;
 
-    //
-    // ID conversion and materialization operations.
-    //
-
-    /// Gets or creates a goal ID for a given goal.
-    ///
-    /// # Parameters
-    /// * `goal` - The goal to get or create an ID for.
-    ///
-    /// # Returns
-    /// The ID of the goal.
-    async fn get_goal_id(&mut self, goal: &Goal) -> MemoResult<GoalId>;
-
-    /// Materializes a goal from its ID.
-    ///
-    /// # Parameters
-    /// * `goal_id` - ID of the goal to materialize.
-    ///
-    /// # Returns
-    /// The materialized goal.
-    async fn materialize_goal(&self, goal_id: GoalId) -> MemoResult<Goal>;
-
-    /// Gets or creates a logical expression ID for a given logical expression.
-    ///
-    /// # Parameters
-    /// * `logical_expr` - The logical expression to get or create an ID for.
-    ///
-    /// # Returns
-    /// The ID of the logical expression.
-    async fn get_logical_expr_id(
-        &mut self,
-        logical_expr: &LogicalExpression,
-    ) -> MemoResult<LogicalExpressionId>;
-
-    /// Materializes a logical expression from its ID.
-    ///
-    /// # Parameters
-    /// * `logical_expr_id` - ID of the logical expression to materialize.
-    ///
-    /// # Returns
-    /// The materialized logical expression.
-    async fn materialize_logical_expr(
-        &self,
-        logical_expr_id: LogicalExpressionId,
-    ) -> MemoResult<LogicalExpression>;
-
-    /// Gets or creates a physical expression ID for a given physical expression.
-    ///
-    /// # Parameters
-    /// * `physical_expr` - The physical expression to get or create an ID for.
-    ///
-    /// # Returns
-    /// The ID of the physical expression.
-    async fn get_physical_expr_id(
-        &mut self,
-        physical_expr: &PhysicalExpression,
-    ) -> MemoResult<PhysicalExpressionId>;
-
-    /// Materializes a physical expression from its ID.
-    ///
-    /// # Parameters
-    /// * `physical_expr_id` - ID of the physical expression to materialize.
-    ///
-    /// # Returns
-    /// The materialized physical expression.
-    async fn materialize_physical_expr(
+    async fn get_physical_expr_cost(
         &self,
         physical_expr_id: PhysicalExpressionId,
-    ) -> MemoResult<PhysicalExpression>;
+    ) -> MemoResult<Option<Cost>>;
+}
 
-    //
-    // Representative ID operations.
-    //
-
-    /// Finds the representative group ID for a given group ID.
+/// Rule and costing status operations.
+///
+/// TODO(connor): Clean up docs.
+#[trait_variant::make(Send)]
+pub trait TaskGraphState {
+    /// Checks the status of applying a transformation rule on a logical expression ID.
     ///
     /// # Parameters
-    /// * `group_id` - The group ID to find the representative for.
+    /// * `logical_expr_id` - ID of the logical expression to check.
+    /// * `rule` - Transformation rule to check status for.
     ///
     /// # Returns
-    /// The representative group ID (which may be the same as the input if
-    /// it's already the representative).
-    async fn find_repr_group_id(&self, group_id: GroupId) -> MemoResult<GroupId>;
-
-    /// Finds the representative goal ID for a given goal ID.
-    ///
-    /// # Parameters
-    /// * `goal_id` - The goal ID to find the representative for.
-    ///
-    /// # Returns
-    /// The representative goal ID (which may be the same as the input if
-    /// it's already the representative).
-    async fn find_repr_goal_id(&self, goal_id: GoalId) -> MemoResult<GoalId>;
-
-    /// Finds the representative logical expression ID for a given logical expression ID.
-    ///
-    /// # Parameters
-    /// * `logical_expr_id` - The logical expression ID to find the representative for.
-    ///
-    /// # Returns
-    /// The representative logical expression ID (which may be the same as the input if
-    /// it's already the representative).
-    async fn find_repr_logical_expr_id(
+    /// `Status::Dirty` if there are ongoing events that may affect the transformation,
+    /// `Status::Clean` if the transformation does not need to be re-evaluated.
+    async fn get_transformation_status(
         &self,
         logical_expr_id: LogicalExpressionId,
-    ) -> MemoResult<LogicalExpressionId>;
+        rule: &TransformationRule,
+    ) -> MemoResult<TaskStatus>;
 
-    /// Finds the representative physical expression ID for a given physical expression ID.
+    /// Sets the status of a transformation rule as clean on a logical expression ID.
     ///
     /// # Parameters
-    /// * `physical_expr_id` - The physical expression ID to find the representative for.
+    /// * `logical_expr_id` - ID of the logical expression to update.
+    /// * `rule` - Transformation rule to set status for.
+    async fn set_transformation_clean(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        rule: &TransformationRule,
+    ) -> MemoResult<()>;
+
+    /// Checks the status of applying an implementation rule on a logical expression ID and goal ID.
+    ///
+    /// # Parameters
+    /// * `logical_expr_id` - ID of the logical expression to check.
+    /// * `goal_id` - ID of the goal to check against.
+    /// * `rule` - Implementation rule to check status for.
     ///
     /// # Returns
-    /// The representative physical expression ID (which may be the same as the input if
-    /// it's already the representative).
-    async fn find_repr_physical_expr_id(
+    /// `Status::Dirty` if there are ongoing events that may affect the implementation,
+    /// `Status::Clean` if the implementation does not need to be re-evaluated.
+    async fn get_implementation_status(
+        &self,
+        logical_expr_id: LogicalExpressionId,
+        goal_id: GoalId,
+        rule: &ImplementationRule,
+    ) -> MemoResult<TaskStatus>;
+
+    /// Sets the status of an implementation rule as clean on a logical expression ID and goal ID.
+    ///
+    /// # Parameters
+    /// * `logical_expr_id` - ID of the logical expression to update.
+    /// * `goal_id` - ID of the goal to update against.
+    /// * `rule` - Implementation rule to set status for.
+    async fn set_implementation_clean(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        goal_id: GoalId,
+        rule: &ImplementationRule,
+    ) -> MemoResult<()>;
+
+    /// Checks the status of costing a physical expression ID.
+    ///
+    /// # Parameters
+    /// * `physical_expr_id` - ID of the physical expression to check.
+    ///
+    /// # Returns
+    /// `Status::Dirty` if there are ongoing events that may affect the costing,
+    /// `Status::Clean` if the costing does not need to be re-evaluated.
+    async fn get_cost_status(
         &self,
         physical_expr_id: PhysicalExpressionId,
-    ) -> MemoResult<PhysicalExpressionId>;
+    ) -> MemoResult<TaskStatus>;
+
+    /// Sets the status of costing a physical expression ID as clean.
+    ///
+    /// # Parameters
+    /// * `physical_expr_id` - ID of the physical expression to update.
+    async fn set_cost_clean(&mut self, physical_expr_id: PhysicalExpressionId) -> MemoResult<()>;
+
+    /// Adds a dependency between a transformation rule application and a group.
+    ///
+    /// This registers that the application of the transformation rule on the logical expression
+    /// depends on the group. When the group changes, the transformation status should be set to dirty.
+    ///
+    /// # Parameters
+    /// * `logical_expr_id` - ID of the logical expression the rule is applied to.
+    /// * `rule` - Transformation rule that depends on the group.
+    /// * `group_id` - ID of the group that the transformation depends on.
+    async fn add_transformation_dependency(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        rule: &TransformationRule,
+        group_id: GroupId,
+    ) -> MemoResult<()>;
+
+    /// Adds a dependency between an implementation rule application and a group.
+    ///
+    /// This registers that the application of the implementation rule on the logical expression
+    /// for a specific goal depends on the group. When the group changes, the implementation status
+    /// should be set to dirty.
+    ///
+    /// # Parameters
+    /// * `logical_expr_id` - ID of the logical expression the rule is applied to.
+    /// * `goal_id` - ID of the goal the implementation targets.
+    /// * `rule` - Implementation rule that depends on the group.
+    /// * `group_id` - ID of the group that the implementation depends on.
+    async fn add_implementation_dependency(
+        &mut self,
+        logical_expr_id: LogicalExpressionId,
+        goal_id: GoalId,
+        rule: &ImplementationRule,
+        group_id: GroupId,
+    ) -> MemoResult<()>;
+
+    /// Adds a dependency between costing a physical expression and a goal.
+    ///
+    /// This registers that the costing of the physical expression depends on the goal.
+    /// When the goal changes, the costing status should be set to dirty.
+    ///
+    /// # Parameters
+    /// * `physical_expr_id` - ID of the physical expression to cost.
+    /// * `goal_id` - ID of the goal that the costing depends on.
+    async fn add_cost_dependency(
+        &mut self,
+        physical_expr_id: PhysicalExpressionId,
+        goal_id: GoalId,
+    ) -> MemoResult<()>;
 }

--- a/optd/src/memo/types.rs
+++ b/optd/src/memo/types.rs
@@ -1,0 +1,152 @@
+use crate::cir::*;
+use std::collections::HashSet;
+
+/// The status of rule application or costing operation in the task graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatus {
+    /// There exist ongoing jobs that may generate more expressions or costs from this expression.
+    Dirty,
+
+    /// Expression is fully explored or costed with no pending jobs that could add anything new.
+    Clean,
+}
+
+/// The result of merging two groups.
+///
+/// TODO(sarvesh): More detailed docs.
+#[derive(Debug)]
+pub struct GroupMergeProduct {
+    /// ID of the new representative group id.
+    pub repr_group_id: GroupId,
+
+    /// TODO(sarvesh): More detailed docs.
+    pub non_repr_group_id: GroupId,
+
+    /// All expressions in the merged group.
+    ///
+    /// A key assumption here is that all expressions here are representative expressions (i.e. the
+    /// children group IDs of the expressions are all representative group IDs).
+    pub all_exprs_in_merged_group: HashSet<LogicalExpressionId>,
+
+    /// The expressions that were in the old non-representative group.
+    ///
+    /// A key assumption here is that all expressions here are representative expressions (i.e. the
+    /// children group IDs of the expressions are all representative group IDs).
+    pub non_repr_group_exprs: HashSet<LogicalExpressionId>,
+
+    /// The expressions that are in the representative group.
+    ///
+    /// A key assumption here is that all expressions here are representative expressions (i.e. the
+    /// children group IDs of the expressions are all representative group IDs).
+    pub repr_group_exprs: HashSet<LogicalExpressionId>,
+}
+
+impl GroupMergeProduct {
+    /// Creates a new MergeGroupResult instance.
+    ///
+    /// # Parameters
+    /// * `merged_groups` - Groups that were merged along with their expressions.
+    /// * `new_repr_group_id` - ID of the new representative group id.
+    pub fn new(repr_group_id: GroupId, non_repr_group_id: GroupId) -> Self {
+        Self {
+            repr_group_id,
+            non_repr_group_id,
+            all_exprs_in_merged_group: HashSet::new(),
+            non_repr_group_exprs: HashSet::new(),
+            repr_group_exprs: HashSet::new(),
+        }
+    }
+}
+
+/// The result of merging two goals.
+#[derive(Debug)]
+pub struct GoalMergeProduct {
+    /// The best costed expression for all merged goals combined.
+    pub best_expr: Option<(PhysicalExpressionId, Cost)>,
+
+    /// The ID of the new representative goal.
+    pub repr_goal_id: GoalId,
+
+    /// The ID of the old non-representative goal.
+    pub non_repr_goal_id: GoalId,
+
+    /// Whether the representative goal contained the best costed expression before merging.
+    pub repr_goal_seen_best_expr_before_merge: bool,
+
+    /// Whether the non-representative goal contained the best costed expression before merging.
+    pub non_repr_goal_seen_best_expr_before_merge: bool,
+
+    /// All members in the merged goal.
+    ///
+    /// Unlike for group merge results, these may not necessarily be representative IDs.
+    ///
+    /// The reasoning for this is that there is an edge case where the merging of two groups results
+    /// in 2 pairs of goals being merged. TODO(sarvesh): Be more specific, or give an example.
+    ///
+    /// However, if one of the goals is a member of the other goals, then we cannot guarantee the
+    /// order in which the merge will happen.
+    ///
+    /// Hence, we cannot guarantee that the members are representative IDs.
+    pub members: HashSet<GoalMemberId>,
+}
+
+/// The result of merging two cost expressions.
+#[derive(Debug)]
+pub struct PhysicalMergeProduct {
+    /// The new representative physical expression ID.
+    pub repr_physical_expr: PhysicalExpressionId,
+
+    /// The non-representative physical expression id.
+    pub non_repr_physical_exprs: PhysicalExpressionId,
+}
+
+/// The result of merge operations with newly dirtied expressions.
+///
+/// TODO(sarvesh): Why do we not have products for logical expression merges?
+#[derive(Debug, Default)]
+pub struct MergeProducts {
+    /// Group merge results.
+    pub group_merges: Vec<GroupMergeProduct>,
+
+    /// Goal merge results.
+    pub goal_merges: Vec<GoalMergeProduct>,
+
+    /// Physical expression merge results.
+    pub physical_expr_merges: Vec<PhysicalMergeProduct>,
+    //
+    // /// Transformations that were marked as dirty and need new application.
+    // pub dirty_transformations: Vec<(LogicalExpressionId, TransformationRule)>,
+
+    // /// Implementations that were marked as dirty and need new application.
+    // pub dirty_implementations: Vec<(LogicalExpressionId, GoalId, ImplementationRule)>,
+
+    // /// Costings that were marked as dirty and need recomputation.
+    // pub dirty_costings: Vec<PhysicalExpressionId>,
+}
+
+/// A type representing the information that needs to sent to the scheduler to propagate the best
+/// physical expression for a goal.
+///
+/// The reason we need this is because the memo table will have propagated the best physical
+/// expression for this goal within the memo table already, and the task graph scheduler needs to be
+/// notified of the changes that have happened.
+pub struct PropagateBestExpression {
+    /// The ID of the best physical expression for a goal.
+    pub physical_expr_id: PhysicalExpressionId,
+
+    /// The cost of the best expression.
+    pub best_cost: Cost,
+
+    /// The goals that the memo table has already propagated this best expression to.
+    pub goals_propagated_to: HashSet<GoalId>,
+}
+
+impl PropagateBestExpression {
+    pub fn new(physical_expr_id: PhysicalExpressionId, best_cost: Cost) -> Self {
+        Self {
+            physical_expr_id,
+            best_cost,
+            goals_propagated_to: HashSet::new(),
+        }
+    }
+}

--- a/optd/src/memo/union_find.rs
+++ b/optd/src/memo/union_find.rs
@@ -4,24 +4,22 @@ use std::hash::Hash;
 /// A specialized Union-Find data structure for tracking group or goal representatives
 /// caused by merges
 ///
-/// Implements union-find with path compression for O(α(n)) amortized time complexity
-pub struct Representative<T> {
+/// Implements union-find with path compression for O(log n) amortized time complexity.
+pub struct UnionFind<T> {
     parents: HashMap<T, T>,
 }
 
-impl<T: Eq + Hash + Clone> Representative<T> {
+impl<T: Eq + Hash + Clone> UnionFind<T> {
     /// Creates a new empty Representative
-    pub(super) fn new() -> Self {
-        Self {
-            parents: HashMap::new(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Finds the representative of the set containing `x`
     /// If `x` doesn't exist, returns `x` as its own representative
     ///
     /// This is a non-mutating find operation that does not perform path compression
-    pub(super) fn find(&self, x: &T) -> T {
+    pub fn find(&self, x: &T) -> T {
         match self.parents.get(x) {
             Some(parent) if parent == x => parent.clone(),
             Some(parent) => self.find(parent),
@@ -33,7 +31,7 @@ impl<T: Eq + Hash + Clone> Representative<T> {
     /// If either element doesn't exist, it's automatically added
     ///
     /// This operation performs path compression during the merge
-    pub(super) fn merge(&mut self, old: &T, new: &T) -> T {
+    pub fn merge(&mut self, old: &T, new: &T) -> T {
         // Ensure both elements exist
         self.parents.entry(old.clone()).or_insert(old.clone());
         self.parents.entry(new.clone()).or_insert(new.clone());
@@ -69,26 +67,34 @@ impl<T: Eq + Hash + Clone> Representative<T> {
     }
 }
 
+impl<T> Default for UnionFind<T> {
+    fn default() -> Self {
+        UnionFind {
+            parents: HashMap::new(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_find_nonexistent() {
-        let repr = Representative::<u32>::new();
+        let repr = UnionFind::<u32>::new();
         assert_eq!(repr.find(&42), 42);
     }
 
     #[test]
     fn test_find_self() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
         repr.parents.insert(42, 42);
         assert_eq!(repr.find(&42), 42);
     }
 
     #[test]
     fn test_find_without_compression() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
         repr.parents.insert(1, 2);
         repr.parents.insert(2, 3);
         repr.parents.insert(3, 4);
@@ -104,7 +110,7 @@ mod tests {
 
     #[test]
     fn test_merge_with_compression() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
         repr.parents.insert(1, 2);
         repr.parents.insert(2, 3);
         repr.parents.insert(3, 4);
@@ -120,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_merge_basic() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
         let result = repr.merge(&1, &2);
         assert_eq!(result, 2);
         assert_eq!(repr.find(&1), 2);
@@ -128,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_merge_existing() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
         repr.parents.insert(1, 1);
         repr.parents.insert(2, 2);
 
@@ -139,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_merge_already_merged() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
         repr.parents.insert(1, 2);
         repr.parents.insert(2, 2);
 
@@ -150,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_merge_chains() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
 
         // Create chain 1->2->3
         repr.merge(&1, &2);
@@ -175,7 +181,7 @@ mod tests {
 
     #[test]
     fn test_merge_with_string_keys() {
-        let mut repr = Representative::<String>::new();
+        let mut repr = UnionFind::<String>::new();
 
         let result = repr.merge(&"old".to_string(), &"new".to_string());
         assert_eq!(result, "new");
@@ -184,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_complex_merges() {
-        let mut repr = Representative::<u32>::new();
+        let mut repr = UnionFind::<u32>::new();
 
         // First set of merges
         repr.merge(&1, &2);

--- a/optd/src/optimizer/bridge/from_cir.rs
+++ b/optd/src/optimizer/bridge/from_cir.rs
@@ -1,22 +1,19 @@
 //! Converts optd's type representations (CIR) into DSL [`Value`]s (HIR).
 
-use crate::{
-    cir::{Child, Cost, Goal, GroupId, LogicalProperties, OperatorData, PartialLogicalPlan, PartialPhysicalPlan, PhysicalProperties, PropertiesData},
-    dsl::analyzer::hir::{
-        self, CoreData, Literal, LogicalOp, Materializable, Operator, PhysicalOp, Value,
-    },
+use crate::cir::*;
+use crate::dsl::analyzer::hir::{
+    self, CoreData, Literal, LogicalOp, Materializable, Operator, PhysicalOp, Value,
 };
-use CoreData::*;
-use Literal::*;
-use Materializable::*;
 use std::sync::Arc;
 
 /// Converts a [`PartialLogicalPlan`] into a [`Value`].
-pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
+pub fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
+    use Materializable::*;
+
     match plan {
         PartialLogicalPlan::UnMaterialized(group_id) => {
             // For unmaterialized logical operators, we create a `Value` with the group ID.
-            Value::new(Logical(UnMaterialized(hir::GroupId(group_id.0))))
+            Value::new(CoreData::Logical(UnMaterialized(hir::GroupId(group_id.0))))
         }
         PartialLogicalPlan::Materialized(node) => {
             // For materialized logical operators, we create a `Value` with the operator data.
@@ -26,18 +23,22 @@ pub(crate) fn partial_logical_to_value(plan: &PartialLogicalPlan) -> Value {
                 children: convert_children_to_values(&node.children, partial_logical_to_value),
             };
 
-            Value::new(Logical(Materialized(LogicalOp::logical(operator))))
+            Value::new(CoreData::Logical(Materialized(LogicalOp::logical(
+                operator,
+            ))))
         }
     }
 }
 
 /// Converts a [`PartialPhysicalPlan`] into a [`Value`].
-pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
+pub fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
+    use Materializable::*;
+
     match plan {
         PartialPhysicalPlan::UnMaterialized(goal) => {
             // For unmaterialized physical operators, we create a `Value` with the goal
             let hir_goal = cir_goal_to_hir(goal);
-            Value::new(Physical(UnMaterialized(hir_goal)))
+            Value::new(CoreData::Physical(UnMaterialized(hir_goal)))
         }
         PartialPhysicalPlan::Materialized(node) => {
             // For materialized physical operators, we create a Value with the operator data
@@ -47,35 +48,37 @@ pub(crate) fn partial_physical_to_value(plan: &PartialPhysicalPlan) -> Value {
                 children: convert_children_to_values(&node.children, partial_physical_to_value),
             };
 
-            Value::new(Physical(Materialized(PhysicalOp::physical(operator))))
+            Value::new(CoreData::Physical(Materialized(PhysicalOp::physical(
+                operator,
+            ))))
         }
     }
 }
 
 // TODO(Alexis): Once we define statistics, there should be a custom CIR representation.
 /// Converts a [`PartialPhysicalPlan`]  with its cost into a [`Value`].
-pub(crate) fn costed_physical_to_value(plan: PartialPhysicalPlan, cost: Cost) -> Value {
-    let operator = partial_physical_to_value(&plan);
-    Value::new(Tuple(vec![
+pub fn costed_physical_to_value(plan: PartialPhysicalPlan, cost: Cost) -> Value {
+    // TODO: dead code.
+    let _operator = partial_physical_to_value(&plan);
+    Value::new(CoreData::Tuple(vec![
         partial_physical_to_value(&plan),
-        Value::new(Literal(Float64(cost.0))),
+        Value::new(CoreData::Literal(Literal::Float64(cost.0))),
     ]))
 }
 
 /// Converts [`LogicalProperties`] into a [`Value`].
-#[allow(dead_code)]
-pub(crate) fn logical_properties_to_value(properties: &LogicalProperties) -> Value {
+pub fn logical_properties_to_value(properties: &LogicalProperties) -> Value {
     match &properties.0 {
         Some(data) => properties_data_to_value(data),
-        Option::None => Value::new(None),
+        Option::None => Value::new(CoreData::None),
     }
 }
 
 /// Converts [`PhysicalProperties`] into a [`Value`].
-pub(crate) fn physical_properties_to_value(properties: &PhysicalProperties) -> Value {
+pub fn physical_properties_to_value(properties: &PhysicalProperties) -> Value {
     match &properties.0 {
         Some(data) => properties_data_to_value(data),
-        Option::None => Value::new(None),
+        Option::None => Value::new(CoreData::None),
     }
 }
 
@@ -105,9 +108,9 @@ where
         .iter()
         .map(|child| match child {
             Child::Singleton(item) => converter(item),
-            Child::VarLength(items) => {
-                Value::new(Array(items.iter().map(|item| converter(item)).collect()))
-            }
+            Child::VarLength(items) => Value::new(CoreData::Array(
+                items.iter().map(|item| converter(item)).collect(),
+            )),
         })
         .collect()
 }
@@ -119,35 +122,39 @@ fn convert_operator_data_to_values(data: &[OperatorData]) -> Vec<Value> {
 
 /// Converts an [`OperatorData`] into a [`Value`].
 fn operator_data_to_value(data: &OperatorData) -> Value {
+    use Literal::*;
+
     match data {
-        OperatorData::Int64(i) => Value::new(Literal(Int64(*i))),
-        OperatorData::Float64(f) => Value::new(Literal(Float64(**f))),
-        OperatorData::String(s) => Value::new(Literal(String(s.clone()))),
-        OperatorData::Bool(b) => Value::new(Literal(Bool(*b))),
-        OperatorData::Struct(name, elements) => Value::new(Struct(
+        OperatorData::Int64(i) => Value::new(CoreData::Literal(Int64(*i))),
+        OperatorData::Float64(f) => Value::new(CoreData::Literal(Float64(**f))),
+        OperatorData::String(s) => Value::new(CoreData::Literal(String(s.clone()))),
+        OperatorData::Bool(b) => Value::new(CoreData::Literal(Bool(*b))),
+        OperatorData::Struct(name, elements) => Value::new(CoreData::Struct(
             name.clone(),
             convert_operator_data_to_values(elements),
         )),
         OperatorData::Array(elements) => {
-            Value::new(Array(convert_operator_data_to_values(elements)))
+            Value::new(CoreData::Array(convert_operator_data_to_values(elements)))
         }
     }
 }
 
 /// Converts a [`PropertiesData`] into a [`Value`].
 fn properties_data_to_value(data: &PropertiesData) -> Value {
+    use Literal::*;
+
     match data {
-        PropertiesData::Int64(i) => Value::new(Literal(Int64(*i))),
-        PropertiesData::Float64(f) => Value::new(Literal(Float64(**f))),
-        PropertiesData::String(s) => Value::new(Literal(String(s.clone()))),
-        PropertiesData::Bool(b) => Value::new(Literal(Bool(*b))),
+        PropertiesData::Int64(i) => Value::new(CoreData::Literal(Int64(*i))),
+        PropertiesData::Float64(f) => Value::new(CoreData::Literal(Float64(**f))),
+        PropertiesData::String(s) => Value::new(CoreData::Literal(String(s.clone()))),
+        PropertiesData::Bool(b) => Value::new(CoreData::Literal(Bool(*b))),
         PropertiesData::Struct(name, elements) => {
             let values = elements.iter().map(properties_data_to_value).collect();
-            Value::new(Struct(name.clone(), values))
+            Value::new(CoreData::Struct(name.clone(), values))
         }
         PropertiesData::Array(elements) => {
             let values = elements.iter().map(properties_data_to_value).collect();
-            Value::new(Array(values))
+            Value::new(CoreData::Array(values))
         }
     }
 }

--- a/optd/src/optimizer/bridge/into_cir.rs
+++ b/optd/src/optimizer/bridge/into_cir.rs
@@ -1,15 +1,7 @@
 //! Converts HIR [`Value`]s into optd's type representations (CIR).
 
-use crate::{
-    cir::{
-        Child, Cost, Goal, GroupId, LogicalPlan, LogicalProperties, Operator, OperatorData,
-        PartialLogicalPlan, PartialPhysicalPlan, PhysicalProperties, PropertiesData,
-    },
-    dsl::analyzer::hir::{self, CoreData, Literal, Materializable, Value},
-};
-use CoreData::*;
-use Literal::*;
-use Materializable::*;
+use crate::cir::*;
+use crate::dsl::analyzer::hir::{self, CoreData, Literal, Materializable, Value};
 use std::sync::Arc;
 
 /// Converts a [`Value`] into a [`PartialLogicalPlan`].
@@ -17,9 +9,11 @@ use std::sync::Arc;
 /// # Panics
 ///
 /// Panics if the [`Value`] is not a [`Logical`] variant.
-pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
+pub fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
+    use Materializable::*;
+
     match &value.data {
-        Logical(logical_op) => match logical_op {
+        CoreData::Logical(logical_op) => match logical_op {
             UnMaterialized(group_id) => {
                 PartialLogicalPlan::UnMaterialized(hir_group_id_to_cir(group_id))
             }
@@ -41,9 +35,11 @@ pub(crate) fn value_to_partial_logical(value: &Value) -> PartialLogicalPlan {
 /// # Panics
 ///
 /// Panics if the [`Value`] is not a [`Physical`] variant.
-pub(crate) fn value_to_partial_physical(value: &Value) -> PartialPhysicalPlan {
+pub fn value_to_partial_physical(value: &Value) -> PartialPhysicalPlan {
+    use Materializable::*;
+
     match &value.data {
-        Physical(physical_op) => match physical_op {
+        CoreData::Physical(physical_op) => match physical_op {
             UnMaterialized(hir_goal) => {
                 PartialPhysicalPlan::UnMaterialized(hir_goal_to_cir(hir_goal))
             }
@@ -68,17 +64,17 @@ pub(crate) fn value_to_partial_physical(value: &Value) -> PartialPhysicalPlan {
 /// # Panics
 ///
 /// Panics if the [`Value`] is not a [`Literal`] variant with a [`Float64`] value.
-pub(crate) fn value_to_cost(value: &Value) -> Cost {
+pub fn value_to_cost(value: &Value) -> Cost {
     match &value.data {
-        Literal(Float64(f)) => Cost(*f),
+        CoreData::Literal(Literal::Float64(f)) => Cost(*f),
         _ => panic!("Expected Float64 literal, found: {:?}", value.data),
     }
 }
 
 /// Converts an HIR properties [`Value`] into a CIR [`LogicalProperties`].
-pub(crate) fn value_to_logical_properties(properties_value: &Value) -> LogicalProperties {
+pub fn value_to_logical_properties(properties_value: &Value) -> LogicalProperties {
     match &properties_value.data {
-        None => LogicalProperties(Option::None),
+        CoreData::None => LogicalProperties(Option::None),
         _ => LogicalProperties(Some(value_to_properties_data(properties_value))),
     }
 }
@@ -86,7 +82,7 @@ pub(crate) fn value_to_logical_properties(properties_value: &Value) -> LogicalPr
 /// Convert an HIR properties [`Value`] into a CIR [`PhysicalProperties`].
 fn value_to_physical_properties(properties_value: &Value) -> PhysicalProperties {
     match &properties_value.data {
-        None => PhysicalProperties(Option::None),
+        CoreData::None => PhysicalProperties(Option::None),
         _ => PhysicalProperties(Some(value_to_properties_data(properties_value))),
     }
 }
@@ -95,12 +91,12 @@ fn value_to_physical_properties(properties_value: &Value) -> PhysicalProperties 
 ///
 /// This function provides a consistent way to convert group identifiers from the HIR into the
 /// optimizer's internal representation (CIR).
-pub(crate) fn hir_group_id_to_cir(hir_group_id: &hir::GroupId) -> GroupId {
+pub fn hir_group_id_to_cir(hir_group_id: &hir::GroupId) -> GroupId {
     GroupId(hir_group_id.0)
 }
 
 /// Converts an HIR [`Goal`](hir::Goal) to a CIR [`Goal`].
-pub(crate) fn hir_goal_to_cir(hir_goal: &hir::Goal) -> Goal {
+pub fn hir_goal_to_cir(hir_goal: &hir::Goal) -> Goal {
     let group_id = hir_group_id_to_cir(&hir_goal.group_id);
     let properties = value_to_physical_properties(&hir_goal.properties);
     Goal(group_id, properties)
@@ -114,9 +110,11 @@ pub(crate) fn hir_goal_to_cir(hir_goal: &hir::Goal) -> Goal {
 ///
 /// Panics if the [`Value`] is not a [`Logical`] variant or if the [`Logical`] variant is not a
 /// [`Materialized`] variant.
-fn value_to_logical(value: &Value) -> LogicalPlan {
+pub fn value_to_logical(value: &Value) -> LogicalPlan {
+    use Materializable::*;
+
     match &value.data {
-        Logical(logical_op) => match logical_op {
+        CoreData::Logical(logical_op) => match logical_op {
             UnMaterialized(_) => {
                 panic!("Cannot convert UnMaterialized LogicalOperator to LogicalPlan")
             }
@@ -140,7 +138,7 @@ where
     values
         .iter()
         .map(|value| match &value.data {
-            Array(elements) => Child::VarLength(
+            CoreData::Array(elements) => Child::VarLength(
                 elements
                     .iter()
                     .map(|elem| Arc::new(converter(elem)))
@@ -167,16 +165,18 @@ fn convert_values_to_properties_data(values: &[Value]) -> Vec<PropertiesData> {
 ///
 /// Panics if the [`Value`] cannot be converted to [`OperatorData`], such as a [`Unit`] literal.
 fn value_to_operator_data(value: &Value) -> OperatorData {
+    use Literal::*;
+
     match &value.data {
-        Literal(constant) => match constant {
+        CoreData::Literal(constant) => match constant {
             Int64(i) => OperatorData::Int64(*i),
             Float64(f) => OperatorData::Float64((*f).into()),
             String(s) => OperatorData::String(s.clone()),
             Bool(b) => OperatorData::Bool(*b),
             Unit => panic!("Cannot convert Unit constant to OperatorData"),
         },
-        Array(elements) => OperatorData::Array(convert_values_to_operator_data(elements)),
-        Struct(name, elements) => {
+        CoreData::Array(elements) => OperatorData::Array(convert_values_to_operator_data(elements)),
+        CoreData::Struct(name, elements) => {
             OperatorData::Struct(name.clone(), convert_values_to_operator_data(elements))
         }
         _ => panic!("Cannot convert {:?} to OperatorData", value.data),
@@ -189,16 +189,20 @@ fn value_to_operator_data(value: &Value) -> OperatorData {
 ///
 /// Panics if the [`Value`] cannot be converted to [`PropertiesData`], such as a [`Unit`] literal.
 fn value_to_properties_data(value: &Value) -> PropertiesData {
+    use Literal::*;
+
     match &value.data {
-        Literal(constant) => match constant {
+        CoreData::Literal(constant) => match constant {
             Int64(i) => PropertiesData::Int64(*i),
             Float64(f) => PropertiesData::Float64((*f).into()),
             String(s) => PropertiesData::String(s.clone()),
             Bool(b) => PropertiesData::Bool(*b),
             Unit => panic!("Cannot convert Unit constant to PropertyData"),
         },
-        Array(elements) => PropertiesData::Array(convert_values_to_properties_data(elements)),
-        Struct(name, elements) => {
+        CoreData::Array(elements) => {
+            PropertiesData::Array(convert_values_to_properties_data(elements))
+        }
+        CoreData::Struct(name, elements) => {
             PropertiesData::Struct(name.clone(), convert_values_to_properties_data(elements))
         }
         _ => panic!("Cannot convert {:?} to PropertyData content", value.data),


### PR DESCRIPTION
## Summary of changes

This PR moves the memo table from the previous WIP branch over to this fresh branch.

It is not completely cleaned up yet. I am considering removing `memory.rs` for now while I clean it up.

Also, I cleaned up the bridges to not use glob imports