### PR TITLE
Memory memo tests

### DIFF
--- a/optd/src/memo/memory.rs
+++ b/optd/src/memo/memory.rs
@@ -1131,3 +1131,77 @@ impl MemoryMemo {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::memo::tests::*;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_lookup_same() {
+        let mut memo = MemoryMemo::default();
+
+        let g0 = lookup_or_insert(&mut memo, 0, Vec::new()).await;
+        let g1 = lookup_or_insert(&mut memo, 0, Vec::new()).await;
+
+        assert_eq!(g0, g1);
+    }
+
+    #[tokio::test]
+    async fn test_lookup_different() {
+        let mut memo = MemoryMemo::default();
+
+        let g0 = lookup_or_insert(&mut memo, 0, Vec::new()).await;
+        let g1 = lookup_or_insert(&mut memo, 1, Vec::new()).await;
+
+        assert_ne!(g0, g1);
+    }
+
+    #[tokio::test]
+    async fn test_add_to_group() {
+        let mut memo = MemoryMemo::default();
+
+        let g0 = lookup_or_insert(&mut memo, 0, Vec::new()).await;
+        insert_into_group(&mut memo, 1, Vec::new(), g0).await;
+
+        assert_eq!(retrieve(&memo, g0).await, vec![0, 1]);
+    }
+
+    #[tokio::test]
+    async fn test_merge() {
+        let mut memo = MemoryMemo::default();
+
+        let g0 = lookup_or_insert(&mut memo, 0, Vec::new()).await;
+        insert_into_group(&mut memo, 1, Vec::new(), g0).await;
+        let g2 = lookup_or_insert(&mut memo, 2, Vec::new()).await;
+        insert_into_group(&mut memo, 3, Vec::new(), g2).await;
+        let g4 = insert_into_group(&mut memo, 0, Vec::new(), g2).await;
+
+        assert_eq!(retrieve(&memo, g4).await, vec![0, 1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_recursive_merge() {
+        let mut memo = MemoryMemo::default();
+
+        let g0 = lookup_or_insert(&mut memo, 0, Vec::new()).await;
+        let g1 = insert_into_group(&mut memo, 1, Vec::new(), g0).await;
+        let g4 = lookup_or_insert(&mut memo, 4, vec![g1]).await;
+        insert_into_group(&mut memo, 5, Vec::new(), g4).await;
+
+        let g2 = lookup_or_insert(&mut memo, 2, Vec::new()).await;
+        let g3 = insert_into_group(&mut memo, 3, Vec::new(), g2).await;
+        let g5 = lookup_or_insert(&mut memo, 4, vec![g3]).await;
+        insert_into_group(&mut memo, 6, Vec::new(), g5).await;
+
+        // trigger recursive merge
+        let g6 = insert_into_group(&mut memo, 1, Vec::new(), g3).await;
+
+        assert_eq!(retrieve(&memo, g6).await, vec![0, 1, 2, 3]);
+
+        // get merged upper group
+        let g7 = lookup_or_insert(&mut memo, 4, vec![g6]).await;
+
+        assert_eq!(retrieve(&memo, g7).await, vec![4, 5, 6]);
+    }
+}

--- a/optd/src/memo/traits.rs
+++ b/optd/src/memo/traits.rs
@@ -400,3 +400,44 @@ pub trait Memoize: Send + Sync + 'static {
         physical_expr_id: PhysicalExpressionId,
     ) -> MemoResult<PhysicalExpressionId>;
 }
+
+#[cfg(test)]
+pub mod tests {
+    use crate::core::cir::OperatorData;
+    use super::*;
+
+    pub async fn lookup_or_insert(memo: &mut impl Memoize, data: i64, children: Vec<GroupId>) -> GroupId {
+        let expr = LogicalExpression {
+            tag: data.to_string(),
+            data: vec![OperatorData::Int64(data)],
+            children: children.iter().map(|g| Child::Singleton(*g)).collect(),
+        };
+
+        let eid = memo.get_logical_expr_id(&expr).await.unwrap();
+        match memo.find_logical_expr_group(eid).await.unwrap() {
+            None => { memo.create_group(eid).await.unwrap() }
+            Some(g) => { g }
+        }
+    }
+
+    pub async fn insert_into_group(memo: &mut impl Memoize, data: i64, children: Vec<GroupId>, gid: GroupId) -> GroupId {
+        let g = lookup_or_insert(memo, data, children).await;
+        memo.merge_groups(g, gid).await.unwrap();
+        g
+    }
+
+    pub async fn retrieve(memo: &impl Memoize, gid: GroupId) -> Vec<i64> {
+        let eids = memo.get_all_logical_exprs(gid).await.unwrap();
+
+        // collect and sort data in expressions
+        let mut data = vec![];
+        for eid in eids {
+            let expr = memo.materialize_logical_expr(eid).await.unwrap();
+            if let OperatorData::Int64(v) = expr.data[0] {
+                data.push(v);
+            }
+        };
+        data.sort();
+        data
+    }
+}


### PR DESCRIPTION
## Problem

The memo is being tested only through optimizer tests.

## Summary of changes

Add simple tests for key memo functionality, including insert, lookup, merge, and recursive merge of groups.

Limitation: These tests are currently using only logical expressions.